### PR TITLE
Add export utilities integration

### DIFF
--- a/src/ui_mainwindow.py
+++ b/src/ui_mainwindow.py
@@ -42,6 +42,7 @@ from logic import (
     save_plot
 )
 from ui_wizard import Wizard
+import utils
 
 
 def show_error(parent, msg):
@@ -703,10 +704,29 @@ class ABTestWindow(QMainWindow):
         QMessageBox.information(self, "Info", "Загрузка сессии не реализовано")
 
     def export_pdf(self):
-        QMessageBox.information(self, "Info", "Экспорт PDF не реализован")
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save PDF", "", "PDF Files (*.pdf)"
+        )
+        if not path:
+            return
+        try:
+            utils.export_pdf(self.results_text.toPlainText(), path)
+            QMessageBox.information(self, "Success", f"Saved to {path}")
+        except Exception as e:
+            show_error(self, str(e))
 
     def export_excel(self):
-        QMessageBox.information(self, "Info", "Экспорт Excel не реализован")
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Excel", "", "Excel Files (*.xlsx)"
+        )
+        if not path:
+            return
+        try:
+            sections = {"Results": self.results_text.toPlainText().splitlines()}
+            utils.export_excel(sections, path)
+            QMessageBox.information(self, "Success", f"Saved to {path}")
+        except Exception as e:
+            show_error(self, str(e))
 
 
 if __name__ == "__main__":

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import types
+import statistics
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Stubs for optional dependencies
+if 'numpy' not in sys.modules:
+    sys.modules['numpy'] = types.ModuleType('numpy')
+
+if 'scipy.stats' not in sys.modules:
+    nd = statistics.NormalDist()
+    class Norm:
+        @staticmethod
+        def ppf(p):
+            return nd.inv_cdf(p)
+        @staticmethod
+        def cdf(x):
+            return nd.cdf(x)
+    stats_mod = types.ModuleType('scipy.stats')
+    stats_mod.norm = Norm
+    stats_mod.beta = types.SimpleNamespace(pdf=lambda *a, **k: None,
+                                           cdf=lambda *a, **k: None)
+    scipy_mod = types.ModuleType('scipy')
+    scipy_mod.stats = stats_mod
+    sys.modules['scipy'] = scipy_mod
+    sys.modules['scipy.stats'] = stats_mod
+
+if 'plotly.graph_objects' not in sys.modules:
+    plotly_mod = types.ModuleType('plotly')
+    go_mod = types.ModuleType('graph_objects')
+    plotly_mod.graph_objects = go_mod
+    sys.modules['plotly'] = plotly_mod
+    sys.modules['plotly.graph_objects'] = go_mod
+
+# Stub reportlab used in utils
+if 'reportlab' not in sys.modules:
+    rl_mod = types.ModuleType('reportlab')
+    lib_mod = types.ModuleType('reportlab.lib')
+    pagesizes_mod = types.ModuleType('reportlab.lib.pagesizes')
+    pagesizes_mod.letter = (0, 0)
+    pdfgen_mod = types.ModuleType('reportlab.pdfgen')
+    pdfgen_mod.canvas = types.SimpleNamespace(Canvas=lambda *a, **k: None)
+    pdfbase_mod = types.ModuleType('reportlab.pdfbase')
+    pdfmetrics_mod = types.ModuleType('reportlab.pdfbase.pdfmetrics')
+    pdfmetrics_mod.registerFont = lambda *a, **k: None
+    ttfonts_mod = types.ModuleType('reportlab.pdfbase.ttfonts')
+    ttfonts_mod.TTFont = type('TTFont', (), {})
+    pdfbase_mod.pdfmetrics = pdfmetrics_mod
+    pdfbase_mod.ttfonts = ttfonts_mod
+    rl_mod.lib = lib_mod
+    rl_mod.pdfgen = pdfgen_mod
+    rl_mod.pdfbase = pdfbase_mod
+    sys.modules['reportlab'] = rl_mod
+    sys.modules['reportlab.lib'] = lib_mod
+    sys.modules['reportlab.lib.pagesizes'] = pagesizes_mod
+    sys.modules['reportlab.pdfgen'] = pdfgen_mod
+    sys.modules['reportlab.pdfbase'] = pdfbase_mod
+    sys.modules['reportlab.pdfbase.pdfmetrics'] = pdfmetrics_mod
+    sys.modules['reportlab.pdfbase.ttfonts'] = ttfonts_mod
+
+# Additional stubs needed for ui_mainwindow
+if 'pandas' not in sys.modules:
+    sys.modules['pandas'] = types.ModuleType('pandas')
+
+pyqt6_mod = sys.modules.get('PyQt6') or types.ModuleType('PyQt6')
+widgets_mod = sys.modules.get('PyQt6.QtWidgets') or types.ModuleType('PyQt6.QtWidgets')
+gui_mod = sys.modules.get('PyQt6.QtGui') or types.ModuleType('PyQt6.QtGui')
+core_mod = sys.modules.get('PyQt6.QtCore') or types.ModuleType('PyQt6.QtCore')
+
+widget_names = [
+    'QApplication','QMainWindow','QWidget','QVBoxLayout','QHBoxLayout',
+    'QGridLayout','QLabel','QLineEdit','QPushButton','QSlider',
+    'QDoubleSpinBox','QTabWidget','QTableWidget','QTableWidgetItem',
+    'QTextBrowser','QWizard','QWizardPage'
+]
+for name in widget_names:
+    if not hasattr(widgets_mod, name):
+        setattr(widgets_mod, name, type(name, (), {}))
+
+class QFileDialog:
+    @staticmethod
+    def getSaveFileName(*args, **kwargs):
+        return ('', '')
+widgets_mod.QFileDialog = QFileDialog
+
+class QMessageBox:
+    @staticmethod
+    def information(*args, **kwargs):
+        pass
+    @staticmethod
+    def critical(*args, **kwargs):
+        pass
+widgets_mod.QMessageBox = QMessageBox
+
+pyqt6_mod.QtWidgets = widgets_mod
+
+for name in ['QPalette','QColor','QIntValidator','QDoubleValidator','QAction']:
+    if not hasattr(gui_mod, name):
+        setattr(gui_mod, name, type(name, (), {}))
+pyqt6_mod.QtGui = gui_mod
+
+if not hasattr(core_mod, 'Qt'):
+    core_mod.Qt = type('Qt', (), {})
+if not hasattr(core_mod, 'QDateTime'):
+    core_mod.QDateTime = type('QDateTime', (), {})
+pyqt6_mod.QtCore = core_mod
+
+sys.modules['PyQt6'] = pyqt6_mod
+sys.modules['PyQt6.QtWidgets'] = widgets_mod
+sys.modules['PyQt6.QtGui'] = gui_mod
+sys.modules['PyQt6.QtCore'] = core_mod
+
+from ui_mainwindow import ABTestWindow, QFileDialog, utils
+
+
+def test_export_pdf_invokes_util(monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(QFileDialog, 'getSaveFileName', lambda *a, **k: ('out.pdf', ''))
+    monkeypatch.setattr(utils, 'export_pdf', lambda html, path: recorded.setdefault('args', (html, path)))
+
+    dummy = types.SimpleNamespace(results_text=types.SimpleNamespace(toPlainText=lambda: 'text'))
+    ABTestWindow.export_pdf(dummy)
+
+    assert recorded.get('args') == ('text', 'out.pdf')
+
+
+def test_export_excel_invokes_util(monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(QFileDialog, 'getSaveFileName', lambda *a, **k: ('out.xlsx', ''))
+    monkeypatch.setattr(utils, 'export_excel', lambda sec, path: recorded.setdefault('args', (sec, path)))
+
+    dummy = types.SimpleNamespace(results_text=types.SimpleNamespace(toPlainText=lambda: 'line1\nline2'))
+    ABTestWindow.export_excel(dummy)
+
+    assert recorded.get('args') == ({'Results': ['line1', 'line2']}, 'out.xlsx')


### PR DESCRIPTION
## Summary
- wire up export functions in the main window
- save results to chosen paths via QFileDialog
- test that export handlers invoke the util functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703a789e7c832c90cca2ec50871486