### PR TITLE
Add conversion count validation

### DIFF
--- a/src/logic.py
+++ b/src/logic.py
@@ -45,6 +45,15 @@ def evaluate_abn_test(
     if users_c is not None and users_c <= 0:
         raise ValueError("Кол-во пользователей должно быть >0")
 
+    if not (0 <= conv_a <= users_a):
+        raise ValueError("Количество конверсий A должно быть от 0 до users_a")
+
+    if not (0 <= conv_b <= users_b):
+        raise ValueError("Количество конверсий B должно быть от 0 до users_b")
+
+    if users_c is not None and conv_c is not None and not (0 <= conv_c <= users_c):
+        raise ValueError("Количество конверсий C должно быть от 0 до users_c")
+
     cr_a = conv_a / users_a
     cr_b = conv_b / users_b
     cr_c = conv_c / users_c if users_c is not None and conv_c is not None else None

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,6 +3,7 @@ import sys
 import types
 import statistics
 import math
+import pytest
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -60,3 +61,14 @@ def test_evaluate_abn_test_no_difference():
     res = evaluate_abn_test(1000, 100, 1000, 100, 1000, 100)
     assert not res['significant_ab']
     assert not res['significant_ac']
+
+
+def test_evaluate_abn_test_invalid_counts():
+    with pytest.raises(ValueError):
+        evaluate_abn_test(10, -1, 10, 0)
+
+    with pytest.raises(ValueError):
+        evaluate_abn_test(10, 5, 10, 11)
+
+    with pytest.raises(ValueError):
+        evaluate_abn_test(10, 5, 10, 5, 5, 6)


### PR DESCRIPTION
## Summary
- validate conversion counts in `evaluate_abn_test`
- add tests covering invalid conversion counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703a77dffc832c9a3fa61ede3c9722