### PR TITLE
Add CSV export option

### DIFF
--- a/src/ui_mainwindow.py
+++ b/src/ui_mainwindow.py
@@ -105,7 +105,8 @@ class ABTestWindow(QMainWindow):
                 'save_session': "Сохранить сессию",
                 'load_session': "Загрузить сессию",
                 'export_pdf': "Экспорт PDF",
-                'export_excel': "Экспорт Excel"
+                'export_excel': "Экспорт Excel",
+                'export_csv': "Экспорт CSV"
             },
             'EN': {
                 'title': "Ultimate A/B Testing Tool",
@@ -140,7 +141,8 @@ class ABTestWindow(QMainWindow):
                 'save_session': "Save session",
                 'load_session': "Load session",
                 'export_pdf': "Export PDF",
-                'export_excel': "Export Excel"
+                'export_excel': "Export Excel",
+                'export_csv': "Export CSV"
             }
         }
 
@@ -474,6 +476,9 @@ class ABTestWindow(QMainWindow):
         a4 = QAction(L['export_excel'], self)
         a4.triggered.connect(self.export_excel)
         fm.addAction(a4)
+        a5 = QAction(L['export_csv'], self)
+        a5.triggered.connect(self.export_csv)
+        fm.addAction(a5)
 
         # Tutorial / Справка
         hm = mb.addMenu(L['tutorial'])
@@ -724,6 +729,19 @@ class ABTestWindow(QMainWindow):
         try:
             sections = {"Results": self.results_text.toPlainText().splitlines()}
             utils.export_excel(sections, path)
+            QMessageBox.information(self, "Success", f"Saved to {path}")
+        except Exception as e:
+            show_error(self, str(e))
+
+    def export_csv(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save CSV", "", "CSV Files (*.csv)"
+        )
+        if not path:
+            return
+        try:
+            sections = {"Results": self.results_text.toPlainText().splitlines()}
+            utils.export_csv(sections, path)
             QMessageBox.information(self, "Success", f"Saved to {path}")
         except Exception as e:
             show_error(self, str(e))

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 # utils.py
 from PyQt6.QtWidgets import QMessageBox
 import json
+import csv
 import pandas as pd
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas as pdfcanvas
@@ -52,6 +53,17 @@ def export_excel(sections, filepath):
             rows = [line.strip().split(":") for line in lines if ":" in line]
             df = pd.DataFrame(rows, columns=["Metric", "Value"])
             df.to_excel(writer, sheet_name=name[:31], index=False)
+
+def export_csv(sections, filepath):
+    with open(filepath, 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        for name, lines in sections.items():
+            w.writerow([name])
+            for line in lines:
+                if ':' in line:
+                    metric, value = [p.strip() for p in line.split(':', 1)]
+                    w.writerow([metric, value])
+            w.writerow([])
 
 def show_error(parent, message):
     QMessageBox.critical(parent, "Ошибка", message)

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -135,3 +135,14 @@ def test_export_excel_invokes_util(monkeypatch):
     ABTestWindow.export_excel(dummy)
 
     assert recorded.get('args') == ({'Results': ['line1', 'line2']}, 'out.xlsx')
+
+
+def test_export_csv_invokes_util(monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(QFileDialog, 'getSaveFileName', lambda *a, **k: ('out.csv', ''))
+    monkeypatch.setattr(utils, 'export_csv', lambda sec, path: recorded.setdefault('args', (sec, path)))
+
+    dummy = types.SimpleNamespace(results_text=types.SimpleNamespace(toPlainText=lambda: 'line1\nline2'))
+    ABTestWindow.export_csv(dummy)
+
+    assert recorded.get('args') == ({'Results': ['line1', 'line2']}, 'out.csv')


### PR DESCRIPTION
## Summary
- add `export_csv` utility to output results as CSV
- support new option in main window translations and menu
- implement `export_csv` method for `ABTestWindow`
- test the new export function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870421fd5c8832c8fc5b0364990aee5