### PR TITLE
Add FDR adjustment, bandit allocation, and CSV import

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -67,3 +67,26 @@ def export_csv(sections, filepath):
 
 def show_error(parent, message):
     QMessageBox.critical(parent, "Ошибка", message)
+
+def load_counts_from_csv(filepath):
+    """Читает первый ряд CSV с колонками users_A, conv_A и т.д."""
+    with open(filepath, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        row = next(reader, None)
+        if row is None:
+            raise ValueError('CSV is empty')
+
+    def get(col):
+        for k, v in row.items():
+            if k.lower() == col:
+                return int(float(v))
+        return 0
+
+    return {
+        'users_a': get('users_a'),
+        'conv_a': get('conv_a'),
+        'users_b': get('users_b'),
+        'conv_b': get('conv_b'),
+        'users_c': get('users_c'),
+        'conv_c': get('conv_c'),
+    }

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,6 +3,7 @@ import sys
 import types
 import statistics
 import math
+import csv
 import pytest
 
 # Add src to path
@@ -10,7 +11,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 # Minimal stubs for optional dependencies
 if 'numpy' not in sys.modules:
-    sys.modules['numpy'] = types.ModuleType('numpy')
+    np_mod = types.ModuleType('numpy')
+    def linspace(a, b, n):
+        step = (b - a) / (n - 1)
+        return [a + step * i for i in range(n)]
+    np_mod.linspace = linspace
+    np_mod.trapz = lambda y, x: sum((y[i] + y[i+1]) * (x[i+1] - x[i]) / 2 for i in range(len(y)-1))
+    np_mod.random = types.SimpleNamespace(binomial=lambda n, p, size=None: [0])
+    sys.modules['numpy'] = np_mod
 
 if 'scipy.stats' not in sys.modules:
     nd = statistics.NormalDist()
@@ -45,11 +53,49 @@ if 'PyQt6.QtWidgets' not in sys.modules:
         def getSaveFileName(*args, **kwargs):
             return ('', '')
     widgets_mod.QFileDialog = QFileDialog
+    class QMessageBox:
+        @staticmethod
+        def critical(*args, **kwargs):
+            pass
+    widgets_mod.QMessageBox = QMessageBox
     pyqt6_mod.QtWidgets = widgets_mod
     sys.modules['PyQt6'] = pyqt6_mod
     sys.modules['PyQt6.QtWidgets'] = widgets_mod
 
-from logic import required_sample_size, evaluate_abn_test
+if 'pandas' not in sys.modules:
+    sys.modules['pandas'] = types.ModuleType('pandas')
+
+if 'reportlab' not in sys.modules:
+    rl_mod = types.ModuleType('reportlab')
+    lib_mod = types.ModuleType('reportlab.lib')
+    pagesizes_mod = types.ModuleType('reportlab.lib.pagesizes')
+    pagesizes_mod.letter = (0, 0)
+    pdfgen_mod = types.ModuleType('reportlab.pdfgen')
+    pdfgen_mod.canvas = types.SimpleNamespace(Canvas=lambda *a, **k: None)
+    pdfbase_mod = types.ModuleType('reportlab.pdfbase')
+    pdfmetrics_mod = types.ModuleType('reportlab.pdfbase.pdfmetrics')
+    pdfmetrics_mod.registerFont = lambda *a, **k: None
+    ttfonts_mod = types.ModuleType('reportlab.pdfbase.ttfonts')
+    ttfonts_mod.TTFont = type('TTFont', (), {})
+    rl_mod.lib = lib_mod
+    rl_mod.pdfgen = pdfgen_mod
+    rl_mod.pdfbase = pdfbase_mod
+    sys.modules['reportlab'] = rl_mod
+    sys.modules['reportlab.lib'] = lib_mod
+    sys.modules['reportlab.lib.pagesizes'] = pagesizes_mod
+    sys.modules['reportlab.pdfgen'] = pdfgen_mod
+    sys.modules['reportlab.pdfbase'] = pdfbase_mod
+    sys.modules['reportlab.pdfbase.pdfmetrics'] = pdfmetrics_mod
+    sys.modules['reportlab.pdfbase.ttfonts'] = ttfonts_mod
+
+from logic import (
+    required_sample_size,
+    evaluate_abn_test,
+    evaluate_abn_test_fdr,
+    allocate_bandit,
+)
+from utils import load_counts_from_csv
+from logic import run_obrien_fleming
 
 
 def test_required_sample_size_positive():
@@ -72,3 +118,31 @@ def test_evaluate_abn_test_invalid_counts():
 
     with pytest.raises(ValueError):
         evaluate_abn_test(10, 5, 10, 5, 5, 6)
+
+
+def test_evaluate_abn_test_fdr_adjustment():
+    res = evaluate_abn_test_fdr(100, 10, 100, 20, metrics=2, alpha=0.05)
+    assert 'p_value_fdr' in res
+    assert math.isclose(res['p_value_fdr'], min(res['p_value_ab'] * 2, 1.0))
+
+
+def test_allocate_bandit_counts():
+    a, b = allocate_bandit(1, 1, 50, 10, 50, 15, new_users=20)
+    assert a + b == 20
+
+
+def test_load_counts_from_csv(tmp_path):
+    p = tmp_path / 'data.csv'
+    with open(p, 'w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['users_A','conv_A','users_B','conv_B'])
+        w.writerow([100, 10, 120, 20])
+    data = load_counts_from_csv(str(p))
+    assert data['users_a'] == 100
+    assert data['conv_b'] == 20
+
+
+def test_run_obrien_fleming_steps():
+    steps = run_obrien_fleming(100, 10, 100, 20, alpha=0.05, looks=3)
+    assert isinstance(steps, list) and steps
+    assert 'threshold' in steps[0]


### PR DESCRIPTION
## Summary
- implement `evaluate_abn_test_fdr` with FDR correction
- add `allocate_bandit` using simple Thompson sampling
- support loading A/B/C counts from CSV
- wire CSV loader into UI
- expand tests for new logic and utilities
- add O'Brien-Fleming sequential analysis
- implement session save/load via JSON
- add tooltips and new UI button for O'Brien-Fleming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704439a6b0832c8eed0714a62731e3