### PR TITLE
Add feature flag management module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ reportlab==4.4.2
 setuptools==80.9.0
 tzdata==2025.2
 pytest==8.1.1
+Flask==3.0.3

--- a/src/flags.py
+++ b/src/flags.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+import threading
+
+@dataclass
+class FeatureFlag:
+    """Represents a single feature flag."""
+    name: str
+    enabled: bool = False
+    rollout: float = 100.0  # rollout percentage 0-100
+
+class FeatureFlagStore:
+    """Thread-safe in-memory store for feature flags."""
+    def __init__(self):
+        self._flags: Dict[str, FeatureFlag] = {}
+        self._lock = threading.Lock()
+
+    def create_flag(self, name: str, enabled: bool = False, rollout: float = 100.0) -> FeatureFlag:
+        with self._lock:
+            if name in self._flags:
+                raise ValueError("Flag already exists")
+            if not (0 <= rollout <= 100):
+                raise ValueError("Rollout must be between 0 and 100")
+            flag = FeatureFlag(name=name, enabled=enabled, rollout=rollout)
+            self._flags[name] = flag
+            return flag
+
+    def update_flag(self, name: str, *, enabled: Optional[bool] = None, rollout: Optional[float] = None) -> FeatureFlag:
+        with self._lock:
+            if name not in self._flags:
+                raise KeyError("Flag not found")
+            flag = self._flags[name]
+            if enabled is not None:
+                flag.enabled = enabled
+            if rollout is not None:
+                if not (0 <= rollout <= 100):
+                    raise ValueError("Rollout must be between 0 and 100")
+                flag.rollout = rollout
+            return flag
+
+    def get_flag(self, name: str) -> FeatureFlag:
+        with self._lock:
+            if name not in self._flags:
+                raise KeyError("Flag not found")
+            return self._flags[name]
+
+    def list_flags(self) -> List[FeatureFlag]:
+        with self._lock:
+            return list(self._flags.values())
+
+    def delete_flag(self, name: str) -> None:
+        with self._lock:
+            if name in self._flags:
+                del self._flags[name]

--- a/src/flags_api.py
+++ b/src/flags_api.py
@@ -1,0 +1,48 @@
+from flask import Flask, jsonify, request
+from flags import FeatureFlagStore
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    store = FeatureFlagStore()
+
+    @app.route('/flags', methods=['GET'])
+    def list_flags():
+        flags = store.list_flags()
+        return jsonify([flag.__dict__ for flag in flags])
+
+    @app.route('/flags', methods=['POST'])
+    def create_flag():
+        data = request.get_json(force=True)
+        flag = store.create_flag(
+            data['name'],
+            enabled=data.get('enabled', False),
+            rollout=data.get('rollout', 100.0),
+        )
+        return jsonify(flag.__dict__), 201
+
+    @app.route('/flags/<name>', methods=['PUT'])
+    def update_flag(name):
+        data = request.get_json(force=True)
+        flag = store.update_flag(
+            name,
+            enabled=data.get('enabled'),
+            rollout=data.get('rollout'),
+        )
+        return jsonify(flag.__dict__)
+
+    @app.route('/flags/<name>', methods=['DELETE'])
+    def delete_flag(name):
+        store.delete_flag(name)
+        return '', 204
+
+    return app
+
+
+def main():
+    app = create_app()
+    app.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,33 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import pytest
+from flags import FeatureFlagStore
+
+
+def test_create_and_update_flag():
+    store = FeatureFlagStore()
+    flag = store.create_flag('new', enabled=True, rollout=50)
+    assert flag.name == 'new'
+    assert flag.enabled is True
+    assert flag.rollout == 50
+
+    updated = store.update_flag('new', enabled=False, rollout=20)
+    assert updated.enabled is False
+    assert updated.rollout == 20
+    assert store.get_flag('new').enabled is False
+
+
+def test_create_duplicate_flag():
+    store = FeatureFlagStore()
+    store.create_flag('foo')
+    with pytest.raises(ValueError):
+        store.create_flag('foo')
+
+
+def test_update_invalid_rollout():
+    store = FeatureFlagStore()
+    store.create_flag('bar')
+    with pytest.raises(ValueError):
+        store.update_flag('bar', rollout=120)


### PR DESCRIPTION
## Summary
- add new `FeatureFlag` dataclass and `FeatureFlagStore` for in-memory feature flags
- implement a small Flask REST API to manage flags
- add tests for the feature flag store
- update requirements with Flask dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704b411dac832c9b041df125f02139