### PR TITLE
Add analysis utilities and API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ python src/main.py
 # Запуск тестов
 pytest -q
 ```
+
+## Additional Features
+
+- CUPED adjustment and SRM check helpers
+- Simple alpha-spending curve generation
+- Interactive α-spending plots in the UI
+- Markdown export utility
+- Notebook export utility
+- Basic API to run A/B analyses (`analysis_api.py`)
+- Bandit helpers: UCB1 and epsilon-greedy
+- Webhook helper for early stop notifications
+- Light/Dark theme toggle and sortable history table
+- Simple segmentation helpers and custom metric expressions
+

--- a/src/analysis_api.py
+++ b/src/analysis_api.py
@@ -1,0 +1,29 @@
+from flask import Flask, jsonify, request
+from logic import evaluate_abn_test
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route('/abtest', methods=['POST'])
+    def run_abtest():
+        data = request.get_json(force=True)
+        res = evaluate_abn_test(
+            data['users_a'], data['conv_a'],
+            data['users_b'], data['conv_b'],
+            metrics=data.get('metrics', 1),
+            alpha=data.get('alpha', 0.05),
+        )
+        return jsonify(res)
+
+    return app
+
+
+def main():
+    app = create_app()
+    app.run()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -94,3 +94,11 @@ i18n = {
         "roi_result": "ROI Result",
     },
 }
+
+
+def detect_language() -> str:
+    """Return 'RU' if OS locale starts with ru, else 'EN'."""
+    import locale
+
+    loc = locale.getdefaultlocale()[0] or ''
+    return 'RU' if loc.lower().startswith('ru') else 'EN'

--- a/src/utils.py
+++ b/src/utils.py
@@ -61,3 +61,27 @@ def export_csv(sections, filepath):
 def show_error(parent, message):
     QMessageBox.critical(parent, "Ошибка", message)
 
+
+def export_markdown(sections, filepath):
+    with open(filepath, 'w', encoding='utf-8') as f:
+        for name, lines in sections.items():
+            f.write(f"## {name}\n")
+            for line in lines:
+                f.write(f"{line}\n")
+            f.write("\n")
+
+
+def export_notebook(sections, filepath):
+    """Export results to a minimal Jupyter notebook file."""
+    cells = []
+    for name, lines in sections.items():
+        cell = {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [f"## {name}\n"] + [line + "\n" for line in lines],
+        }
+        cells.append(cell)
+    nb = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 2}
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(nb, f, ensure_ascii=False, indent=2)
+

--- a/src/webhooks.py
+++ b/src/webhooks.py
@@ -1,0 +1,12 @@
+import json
+import urllib.request
+
+
+def send_webhook(url: str, message: str) -> None:
+    """Send a simple POST webhook with text message."""
+    data = json.dumps({"text": message}).encode()
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -7,7 +7,23 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 # Stubs for optional dependencies
 if 'numpy' not in sys.modules:
-    sys.modules['numpy'] = types.ModuleType('numpy')
+    np_mod = types.ModuleType('numpy')
+    np_mod.asarray = lambda x, dtype=None: list(x)
+    np_mod.argmax = lambda arr: arr.index(max(arr))
+    def cov(a, b, ddof=1):
+        mean_a = sum(a) / len(a)
+        mean_b = sum(b) / len(b)
+        cov_ab = sum((ai - mean_a) * (bi - mean_b) for ai, bi in zip(a, b)) / (len(a)-ddof)
+        var_a = sum((ai - mean_a) ** 2 for ai in a) / (len(a)-ddof)
+        var_b = sum((bi - mean_b) ** 2 for bi in b) / (len(a)-ddof)
+        return [[var_a, cov_ab], [cov_ab, var_b]]
+    np_mod.cov = cov
+    np_mod.var = lambda x, ddof=1: sum((xi - sum(x)/len(x))**2 for xi in x) / (len(x)-ddof)
+    np_mod.random = types.SimpleNamespace(
+        randint=lambda a, b=None: 0,
+        random=lambda: 0.0,
+    )
+    sys.modules['numpy'] = np_mod
 
 if 'scipy.stats' not in sys.modules:
     nd = statistics.NormalDist()
@@ -22,6 +38,7 @@ if 'scipy.stats' not in sys.modules:
     stats_mod.norm = Norm
     stats_mod.beta = types.SimpleNamespace(pdf=lambda *a, **k: None,
                                            cdf=lambda *a, **k: None)
+    stats_mod.chi2 = types.SimpleNamespace(cdf=lambda x, df: 1 - math.exp(-x/2))
     scipy_mod = types.ModuleType('scipy')
     scipy_mod.stats = stats_mod
     sys.modules['scipy'] = scipy_mod
@@ -73,7 +90,7 @@ widget_names = [
     'QApplication','QMainWindow','QWidget','QVBoxLayout','QHBoxLayout',
     'QGridLayout','QLabel','QLineEdit','QPushButton','QSlider',
     'QDoubleSpinBox','QTabWidget','QTableWidget','QTableWidgetItem',
-    'QTextBrowser','QWizard','QWizardPage'
+    'QTextBrowser','QWizard','QWizardPage','QComboBox'
 ]
 for name in widget_names:
     if not hasattr(widgets_mod, name):
@@ -149,5 +166,16 @@ def test_export_csv_invokes_util(monkeypatch):
     ABTestWindow.export_csv(dummy)
 
     assert recorded.get('args') == ({'Results': ['line1', 'line2']}, 'out.csv')
+
+
+def test_export_notebook_invokes_util(monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(QFileDialog, 'getSaveFileName', lambda *a, **k: ('out.ipynb', ''))
+    monkeypatch.setattr(utils, 'export_notebook', lambda sec, path: recorded.setdefault('args', (sec, path)))
+
+    dummy = types.SimpleNamespace(results_text=types.SimpleNamespace(toPlainText=lambda: 'line1\nline2'))
+    ABTestWindow.export_notebook(dummy)
+
+    assert recorded.get('args') == ({'Results': ['line1', 'line2']}, 'out.ipynb')
 
 


### PR DESCRIPTION
## Summary
- add CUPED adjustment, SRM check and alpha-spending helpers
- add simple bandit helpers
- provide markdown export utility
- add minimal Flask API for running A/B tests
- document new capabilities in README
- test the new helpers
- add interactive alpha spending plots, segmentation helpers, notebook export
- theme toggle, sortable history table, and bandit algorithm selection in UI
- provide webhook helper and CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687051222f98832c8f03ccee47fb7607