### PR TITLE
Fix analysis API and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pytest -q
 - Markdown export utility
 - Notebook export utility
 - Basic API to run A/B analyses (`analysis_api.py`)
+- Feature flag API with an in-memory store (`flags_api.py`)
 - Bandit helpers: UCB1 and epsilon-greedy
 - Webhook helper for early stop notifications
 - Light/Dark theme toggle and sortable history table

--- a/src/analysis_api.py
+++ b/src/analysis_api.py
@@ -1,3 +1,6 @@
+"""Minimal Flask API exposing core analysis helpers."""
+
+import os
 from flask import Flask, jsonify, request
 from logic import evaluate_abn_test
 
@@ -21,7 +24,8 @@ def create_app() -> Flask:
 
 def main():
     app = create_app()
-    app.run()
+    port = int(os.environ.get("PORT", "5000"))
+    app.run(port=port)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- document the flask analysis API
- expose port configuration via env var
- mention feature flag API in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b8a6b18c832c97f9c8fd3fa781f4