### PR TITLE
Implement SRM warning and improve alpha plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ python src/main.py
 pytest -q
 ```
 
-## Additional Features
+-## Additional Features
 
-- CUPED adjustment and SRM check helpers
+- CUPED adjustment and SRM check helpers (SRM warnings shown before analysis)
 - Simple alpha-spending curve generation
-- Interactive α-spending plots in the UI
+- Interactive α-spending plots in the UI with zoom controls
 - Markdown export utility
 - Notebook export utility
 - Basic API to run A/B analyses (`analysis_api.py`)

--- a/src/logic.py
+++ b/src/logic.py
@@ -404,7 +404,12 @@ def plot_alpha_spending(alpha, looks):
         go.Scatter(x=list(range(1, looks + 1)), y=obf, mode="lines+markers", name="O'Brien-Fleming")
     )
     fig.update_layout(
-        title="Alpha Spending", xaxis_title="Look", yaxis_title="Alpha", margin=dict(l=40, r=20, t=50, b=40)
+        title="Alpha Spending",
+        xaxis_title="Look",
+        yaxis_title="Alpha",
+        hovermode="x unified",
+        xaxis=dict(rangeslider=dict(visible=True)),
+        margin=dict(l=40, r=20, t=50, b=40),
     )
     return fig
 

--- a/src/ui_mainwindow.py
+++ b/src/ui_mainwindow.py
@@ -41,7 +41,8 @@ from logic import (
     plot_confidence_intervals,
     plot_power_curve,
     plot_bootstrap_distribution,
-    save_plot
+    save_plot,
+    srm_check,
 )
 from i18n import i18n, detect_language
 import utils
@@ -521,6 +522,13 @@ class ABTestWindow(QMainWindow):
             ub, cb = int(self.users_B_var.text()), int(self.conv_B_var.text())
             uc, cc = int(self.users_C_var.text()), int(self.conv_C_var.text())
             alpha  = self.alpha_slider.value()/100
+            flag, p = srm_check(ua, ub, alpha=alpha)
+            if flag:
+                QMessageBox.warning(
+                    self,
+                    "SRM detected",
+                    f"SRM check failed (p={p:.3f}). Results may be biased.",
+                )
             res    = evaluate_abn_test(ua, ca, ub, cb, uc, cc, alpha=alpha)
             html   = (f"<pre>A {res['cr_a']:.2%} ({ca}/{ua})\n"
                       f"B {res['cr_b']:.2%} ({cb}/{ub})\n"

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -112,6 +112,9 @@ class QMessageBox:
     @staticmethod
     def critical(*args, **kwargs):
         pass
+    @staticmethod
+    def warning(*args, **kwargs):
+        pass
 widgets_mod.QMessageBox = QMessageBox
 
 pyqt6_mod.QtWidgets = widgets_mod
@@ -132,6 +135,7 @@ sys.modules['PyQt6.QtWidgets'] = widgets_mod
 sys.modules['PyQt6.QtGui'] = gui_mod
 sys.modules['PyQt6.QtCore'] = core_mod
 
+import ui_mainwindow
 from ui_mainwindow import ABTestWindow, QFileDialog, utils
 
 
@@ -183,5 +187,26 @@ def test_export_notebook_invokes_util(monkeypatch):
         'Интерпретация': [],
     }
     assert recorded.get('args') == (expected, 'out.ipynb')
+
+
+def test_analyze_abn_triggers_srm(monkeypatch):
+    warned = {}
+    monkeypatch.setattr(ui_mainwindow.QMessageBox, 'warning', lambda *a, **k: warned.setdefault('called', True))
+    monkeypatch.setattr(ui_mainwindow, 'srm_check', lambda *a, **k: (True, 0.01))
+
+    dummy = types.SimpleNamespace(
+        users_A_var=types.SimpleNamespace(text=lambda: '1000'),
+        conv_A_var=types.SimpleNamespace(text=lambda: '100'),
+        users_B_var=types.SimpleNamespace(text=lambda: '1000'),
+        conv_B_var=types.SimpleNamespace(text=lambda: '110'),
+        users_C_var=types.SimpleNamespace(text=lambda: '0'),
+        conv_C_var=types.SimpleNamespace(text=lambda: '0'),
+        alpha_slider=types.SimpleNamespace(value=lambda: 5),
+        results_text=types.SimpleNamespace(setHtml=lambda x: None),
+        _add_history=lambda *a, **k: None,
+    )
+
+    ABTestWindow._on_analyze_abn(dummy)
+    assert warned.get('called')
 
 


### PR DESCRIPTION
## Summary
- show automatic SRM warning before running A/B/n analysis
- make alpha spending plot interactive with zoom/rangeslider
- document new SRM warning and zoomable alpha plot
- update UI tests for SRM check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870be08efec832ca6aca5d1e1f38005