### PR TITLE
Fix sequential alpha logic and locale detection

### DIFF
--- a/src/i18n.py
+++ b/src/i18n.py
@@ -100,5 +100,6 @@ def detect_language() -> str:
     """Return 'RU' if OS locale starts with ru, else 'EN'."""
     import locale
 
-    loc = locale.getdefaultlocale()[0] or ''
-    return 'RU' if loc.lower().startswith('ru') else 'EN'
+    loc, _ = locale.getlocale()
+    loc = loc or ''
+    return 'RU' if str(loc).lower().startswith('ru') else 'EN'

--- a/src/logic.py
+++ b/src/logic.py
@@ -191,7 +191,9 @@ def run_sequential_analysis(ua, ca, ub, cb, alpha, looks=5, webhook_url=None):
     When ``webhook_url`` is provided, a POST notification is sent if the
     test stops early.
     """
-    pocock_alpha = alpha * (1 - (1 - 0.5**(1/looks)) / (1 - 0.5))
+    if looks <= 0:
+        raise ValueError("looks must be positive")
+    pocock_alpha = alpha / looks
     steps = []
     for i in range(1, looks+1):
         na = int(ua * i/looks)

--- a/src/utils.py
+++ b/src/utils.py
@@ -32,7 +32,7 @@ def validate_numeric(widget, min_val, max_val, percent=False):
 def export_pdf(html, filepath):
     c = pdfcanvas.Canvas(filepath, pagesize=letter)
     c.setFont(PDF_FONT, 10)
-    width, height = letter
+    _, height = letter
     text = c.beginText(40, height - 40)
     text.setLeading(12)
     for line in html.strip().split('\n'):


### PR DESCRIPTION
## Summary
- handle locale detection without deprecated `getdefaultlocale`
- remove unused variable in PDF export
- validate `looks` in sequential tests and simplify alpha logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870bfaa81f4832c8f7cdb241adf3615