### PR TITLE
Add templated PDF export and in-app plot viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -q
 - Simple alpha-spending curve generation
 - Interactive α-spending plots in the UI with zoom controls
 - Markdown export utility
-- Notebook export utility
+- Notebook and PDF export utilities with a common template
 - Basic API to run A/B analyses (`analysis_api.py`)
 - Feature flag API with an in-memory store (`flags_api.py`)
 - Bandit helpers: UCB1 and epsilon-greedy

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,15 +29,22 @@ def validate_numeric(widget, min_val, max_val, percent=False):
         return False
 
 
-def export_pdf(html, filepath):
+def export_pdf(sections, filepath):
+    """Export results following the notebook template into a PDF."""
+    order = ["Описание", "Результаты", "Визуализации", "Интерпретация"]
+
     c = pdfcanvas.Canvas(filepath, pagesize=letter)
     c.setFont(PDF_FONT, 10)
     _, height = letter
-    text = c.beginText(40, height - 40)
-    text.setLeading(12)
-    for line in html.strip().split('\n'):
-        text.textLine(line)
-    c.drawText(text)
+    y = height - 40
+    for name in order:
+        lines = sections.get(name, [])
+        c.drawString(40, y, name)
+        y -= 14
+        for line in lines:
+            c.drawString(60, y, line)
+            y -= 12
+        y -= 10
     c.save()
 
 def export_excel(sections, filepath):

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -142,12 +142,17 @@ from ui_mainwindow import ABTestWindow, QFileDialog, utils
 def test_export_pdf_invokes_util(monkeypatch):
     recorded = {}
     monkeypatch.setattr(QFileDialog, 'getSaveFileName', lambda *a, **k: ('out.pdf', ''))
-    monkeypatch.setattr(utils, 'export_pdf', lambda html, path: recorded.setdefault('args', (html, path)))
+    monkeypatch.setattr(utils, 'export_pdf', lambda sec, path: recorded.setdefault('args', (sec, path)))
 
     dummy = types.SimpleNamespace(results_text=types.SimpleNamespace(toPlainText=lambda: 'text'))
     ABTestWindow.export_pdf(dummy)
-
-    assert recorded.get('args') == ('text', 'out.pdf')
+    expected = {
+        'Описание': [],
+        'Результаты': ['text'],
+        'Визуализации': [],
+        'Интерпретация': [],
+    }
+    assert recorded.get('args') == (expected, 'out.pdf')
 
 
 def test_export_excel_invokes_util(monkeypatch):


### PR DESCRIPTION
## Summary
- make plot viewer use WebEngine when available for interactive plots inside the app
- export PDF reports using the same template as notebook export
- update UI and tests to call the new PDF export API
- document the common template in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c4752864832c9fcf75209b9cff2a