### PR TITLE
Implement persistent feature flags and UI enhancements

### DIFF
--- a/src/analysis_api.py
+++ b/src/analysis_api.py
@@ -19,6 +19,22 @@ def create_app() -> Flask:
         )
         return jsonify(res)
 
+    @app.route('/spec', methods=['GET'])
+    def spec():
+        """Return minimal OpenAPI spec."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Analysis API", "version": "1.0"},
+            "paths": {
+                "/abtest": {
+                    "post": {
+                        "responses": {"200": {"description": "AB test result"}}
+                    }
+                }
+            },
+        }
+        return jsonify(spec)
+
     return app
 
 

--- a/src/flags_api.py
+++ b/src/flags_api.py
@@ -11,6 +11,25 @@ def create_app() -> Flask:
         flags = store.list_flags()
         return jsonify([flag.__dict__ for flag in flags])
 
+    @app.route('/spec', methods=['GET'])
+    def spec():
+        """Return minimal OpenAPI spec."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Flags API", "version": "1.0"},
+            "paths": {
+                "/flags": {
+                    "get": {"responses": {"200": {"description": "List flags"}}},
+                    "post": {"responses": {"201": {"description": "Created"}}},
+                },
+                "/flags/{name}": {
+                    "put": {"responses": {"200": {"description": "Updated"}}},
+                    "delete": {"responses": {"204": {"description": "Deleted"}}},
+                },
+            },
+        }
+        return jsonify(spec)
+
     @app.route('/flags', methods=['POST'])
     def create_flag():
         data = request.get_json(force=True)

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -6,8 +6,8 @@ import pytest
 from flags import FeatureFlagStore
 
 
-def test_create_and_update_flag():
-    store = FeatureFlagStore()
+def test_create_and_update_flag(tmp_path):
+    store = FeatureFlagStore(db_path=str(tmp_path/'db.sqlite'))
     flag = store.create_flag('new', enabled=True, rollout=50)
     assert flag.name == 'new'
     assert flag.enabled is True
@@ -19,15 +19,24 @@ def test_create_and_update_flag():
     assert store.get_flag('new').enabled is False
 
 
-def test_create_duplicate_flag():
-    store = FeatureFlagStore()
+def test_create_duplicate_flag(tmp_path):
+    store = FeatureFlagStore(db_path=str(tmp_path/'db.sqlite'))
     store.create_flag('foo')
     with pytest.raises(ValueError):
         store.create_flag('foo')
 
 
-def test_update_invalid_rollout():
-    store = FeatureFlagStore()
+def test_update_invalid_rollout(tmp_path):
+    store = FeatureFlagStore(db_path=str(tmp_path/'db.sqlite'))
     store.create_flag('bar')
     with pytest.raises(ValueError):
         store.update_flag('bar', rollout=120)
+
+
+def test_store_persists(tmp_path):
+    db = tmp_path / 'db.sqlite'
+    s1 = FeatureFlagStore(db_path=str(db))
+    s1.create_flag('persist', enabled=True)
+    s2 = FeatureFlagStore(db_path=str(db))
+    flag = s2.get_flag('persist')
+    assert flag.enabled is True

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -90,7 +90,7 @@ widget_names = [
     'QApplication','QMainWindow','QWidget','QVBoxLayout','QHBoxLayout',
     'QGridLayout','QLabel','QLineEdit','QPushButton','QSlider',
     'QDoubleSpinBox','QTabWidget','QTableWidget','QTableWidgetItem',
-    'QTextBrowser','QWizard','QWizardPage','QComboBox'
+    'QTextBrowser','QWizard','QWizardPage','QComboBox','QProgressBar'
 ]
 for name in widget_names:
     if not hasattr(widgets_mod, name):


### PR DESCRIPTION
## Summary
- persist feature flags in SQLite
- expose OpenAPI `/spec` routes for analysis and flag APIs
- enhance UI with tooltips, history filtering and inline charts
- adjust tests for new persistence layer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c5744224832cb359f27644fa1cba