### PR TITLE
Fix missing import for alpha-spending plot

### DIFF
--- a/src/ui_mainwindow.py
+++ b/src/ui_mainwindow.py
@@ -42,6 +42,7 @@ from logic import (
     plot_confidence_intervals,
     plot_power_curve,
     plot_bootstrap_distribution,
+    plot_alpha_spending,
     save_plot,
     srm_check,
 )


### PR DESCRIPTION
## Summary
- ensure `plot_alpha_spending` is imported in the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c86475ec832cbf931c910ab9d43a