### PR TITLE
Remove heavy deps and switch exports to Markdown/Notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -q
 - Simple alpha-spending curve generation
 - Interactive α-spending plots in the UI with zoom controls
 - Markdown export utility
-- Notebook and PDF export utilities with a common template
+- Markdown and notebook export utilities with a common template
 - Basic API to run A/B analyses (`analysis_api.py`)
 - Feature flag API with an in-memory store (`flags_api.py`)
 - Bandit helpers: UCB1 and epsilon-greedy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,12 @@
 numpy==2.3.1
-pandas==2.3.0
 matplotlib==3.10.3
 plotly==6.2.0
-scipy==1.16.0
-openpyxl==3.1.5
 pillow==10.4.0
 PyQt6==6.9.1
 PyQt6-Qt6==6.9.1
 PyQt6_sip==13.10.2
 python-dateutil==2.9.0.post0
 pytz==2025.2
-reportlab==4.4.2
 setuptools==80.9.0
 tzdata==2025.2
 pytest==8.1.1

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -3,7 +3,6 @@
 import sys
 import sqlite3
 import csv
-import pandas as pd
 
 from PyQt6.QtWidgets import (
     QApplication,
@@ -216,15 +215,20 @@ class ABTestWindow(QMainWindow):
             show_error(self, str(e))
 
     def _export_history_excel(self):
-        path, _ = QFileDialog.getSaveFileName(self, "Save History Excel", "", "Excel Files (*.xlsx)")
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save History Markdown", "", "Markdown Files (*.md)"
+        )
         if not path:
             return
-        df = pd.read_sql_query(
-            "SELECT timestamp AS Timestamp, test AS Test, result AS Result FROM history ORDER BY id",
-            self.conn
-        )
+        c = self.conn.cursor()
+        c.execute("SELECT timestamp, test, result FROM history ORDER BY id")
+        rows = c.fetchall()
         try:
-            df.to_excel(path, index=False)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("| Timestamp | Test | Result |\n")
+                f.write("|---|---|---|\n")
+                for ts, test, result in rows:
+                    f.write(f"| {ts} | {test} | {result} |\n")
             QMessageBox.information(self, "Success", f"Saved to {path}")
         except Exception as e:
             show_error(self, str(e))

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,44 +2,21 @@ import json
 import csv
 from typing import Any, Dict, Iterable, List
 
-import pandas as pd
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas as pdfcanvas
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
-
-# Try to register font for PDF export
-try:
-    pdfmetrics.registerFont(TTFont('Arial', 'arial.ttf'))
-    PDF_FONT = 'Arial'
-except Exception:  # pragma: no cover - optional
-    PDF_FONT = 'Helvetica'
+"""Utility helpers for exporting results and simple data processing."""
 
 
 def export_pdf(sections: Dict[str, Iterable[str]], filepath: str) -> None:
-    """Export results following the notebook template into a PDF."""
-    order = ["Описание", "Результаты", "Визуализации", "Интерпретация"]
-    c = pdfcanvas.Canvas(filepath, pagesize=letter)
-    c.setFont(PDF_FONT, 10)
-    _, height = letter
-    y = height - 40
-    for name in order:
-        lines = sections.get(name, [])
-        c.drawString(40, y, name)
-        y -= 14
-        for line in lines:
-            c.drawString(60, y, str(line))
-            y -= 12
-        y -= 10
-    c.save()
+    """Export results to a notebook file instead of a PDF."""
+    if filepath.lower().endswith(".pdf"):
+        filepath = filepath[:-4] + ".ipynb"
+    export_notebook(sections, filepath)
 
 
 def export_excel(sections: Dict[str, Iterable[str]], filepath: str) -> None:
-    with pd.ExcelWriter(filepath) as writer:
-        for name, lines in sections.items():
-            rows = [line.strip().split(":") for line in lines if ":" in line]
-            df = pd.DataFrame(rows, columns=["Metric", "Value"])
-            df.to_excel(writer, sheet_name=name[:31], index=False)
+    """Export results to a Markdown file instead of Excel."""
+    if filepath.lower().endswith(('.xls', '.xlsx')):
+        filepath = filepath.rsplit('.', 1)[0] + '.md'
+    export_markdown(sections, filepath)
 
 
 def export_csv(sections: Dict[str, Iterable[str]], filepath: str) -> None:


### PR DESCRIPTION
## Summary
- drop pandas/reportlab/scipy from requirements
- rework utils export helpers to output Markdown and notebooks
- remove pandas usage from UI history export
- adjust docs for new export behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d65af560832c977f93a0e3fad7c5