### PR TITLE
Integrate CUPED and SRM check into analysis

### DIFF
--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -196,7 +196,11 @@ def test_export_notebook_invokes_util(monkeypatch):
 
 def test_analyze_abn_triggers_srm(monkeypatch):
     warned = {}
-    monkeypatch.setattr(ui_mainwindow.QMessageBox, 'warning', lambda *a, **k: warned.setdefault('called', True))
+    def warn(*a, **k):
+        warned.setdefault('called', True)
+        return 1  # Ignore button
+
+    monkeypatch.setattr(ui_mainwindow.QMessageBox, 'warning', warn)
     monkeypatch.setattr(ui_mainwindow, 'srm_check', lambda *a, **k: (True, 0.01))
 
     dummy = types.SimpleNamespace(
@@ -211,7 +215,7 @@ def test_analyze_abn_triggers_srm(monkeypatch):
         _add_history=lambda *a, **k: None,
     )
 
-    ABTestWindow._on_analyze_abn(dummy)
+    ABTestWindow._on_analyze(dummy)
     assert warned.get('called')
 
 


### PR DESCRIPTION
## Summary
- hook up CUPED and SRM helpers inside `ABTestWindow` analysis
- expose new `_on_analyze` method and connect it to Analyze button
- update SRM warning to offer "Ignore" option
- adjust unit test for new handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870dc90ab34832c87d9791db1e6f83b