### PR TITLE
Integrate alpha spending plot

### DIFF
--- a/src/plots/__init__.py
+++ b/src/plots/__init__.py
@@ -82,9 +82,33 @@ def plot_alpha_spending(alpha, looks):
     pocock = pocock_alpha_curve(alpha, looks)
     obf = [2 * (1 - norm.cdf(norm.ppf(1 - alpha / 2) / math.sqrt(i))) for i in range(1, looks + 1)]
     fig = go.Figure()
-    fig.add_trace(go.Scatter(x=list(range(1, looks + 1)), y=pocock, mode="lines+markers", name="Pocock"))
-    fig.add_trace(go.Scatter(x=list(range(1, looks + 1)), y=obf, mode="lines+markers", name="O'Brien-Fleming"))
-    fig.update_layout(title="Alpha Spending", xaxis_title="Look", yaxis_title="Alpha", hovermode="x unified", xaxis=dict(rangeslider=dict(visible=True)), margin=dict(l=40, r=20, t=50, b=40))
+    hover = "Look %{x}<br>α=%{y:.4f}<extra></extra>"
+    fig.add_trace(
+        go.Scatter(
+            x=list(range(1, looks + 1)),
+            y=pocock,
+            mode="lines+markers",
+            name="Pocock",
+            hovertemplate=hover,
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=list(range(1, looks + 1)),
+            y=obf,
+            mode="lines+markers",
+            name="O'Brien-Fleming",
+            hovertemplate=hover,
+        )
+    )
+    fig.update_layout(
+        title="Alpha Spending",
+        xaxis_title="Look",
+        yaxis_title="Alpha",
+        hovermode="x unified",
+        xaxis=dict(rangeslider=dict(visible=True)),
+        margin=dict(l=40, r=20, t=50, b=40),
+    )
     return fig
 
 def save_plot():


### PR DESCRIPTION
## Summary
- embed plotly alpha spending chart directly in main UI
- enable zoom, unified hover and tooltips
- allow saving current plot as HTML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870deb0012c832c939c800a63d4ce1c