### PR TITLE
Add notebook template and update export helpers

### DIFF
--- a/src/utils/template.py
+++ b/src/utils/template.py
@@ -1,0 +1,13 @@
+# Notebook template with four sections
+# Each section is represented by a markdown cell header.
+NB_TEMPLATE = {
+    "cells": [
+        {"cell_type": "markdown", "metadata": {}, "source": ["## Description\n"]},
+        {"cell_type": "markdown", "metadata": {}, "source": ["## Results\n"]},
+        {"cell_type": "markdown", "metadata": {}, "source": ["## Visualizations\n"]},
+        {"cell_type": "markdown", "metadata": {}, "source": ["## Interpretation\n"]},
+    ],
+    "metadata": {},
+    "nbformat": 4,
+    "nbformat_minor": 2,
+}


### PR DESCRIPTION
## Summary
- define a notebook template with 4 sections
- render exports using the template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870e1415a84832cbaa656925f9d226e