### PR TITLE
Add webhook testing form

### DIFF
--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,12 +1,46 @@
 try:
-    from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QLineEdit, QToolTip
+    from PyQt6.QtWidgets import (
+        QWidget,
+        QVBoxLayout,
+        QLabel,
+        QLineEdit,
+        QPushButton,
+        QToolTip,
+    )
     from PyQt6.QtCore import pyqtSignal
 except Exception:  # pragma: no cover - allow running tests without PyQt installed
-    QWidget = type("QWidget", (), {})
-    QVBoxLayout = type("QVBoxLayout", (), {"addWidget": lambda *a, **k: None, "setContentsMargins": lambda *a, **k: None})
-    QLabel = QLineEdit = type("Widget", (), {"text": lambda self: "", "setPlaceholderText": lambda *a, **k: None, "textChanged": lambda *a, **k: None, "setToolTip": lambda *a, **k: None})
+    QWidget = type("QWidget", (), {"__init__": lambda self, *a, **k: None})
+    QVBoxLayout = type(
+        "QVBoxLayout",
+        (),
+        {
+            "__init__": lambda self, *a, **k: None,
+            "addWidget": lambda *a, **k: None,
+            "setContentsMargins": lambda *a, **k: None,
+        },
+    )
+
+    class DummySig:
+        def connect(self, *a, **k):
+            pass
+
+    QLabel = QLineEdit = QPushButton = type(
+        "Widget",
+        (),
+        {
+            "__init__": lambda self, *a, **k: None,
+            "text": lambda self: "",
+            "setPlaceholderText": lambda *a, **k: None,
+            "textChanged": DummySig(),
+            "clicked": DummySig(),
+            "setToolTip": lambda *a, **k: None,
+        },
+    )
     QToolTip = type("QToolTip", (), {"showText": lambda *a, **k: None})
-    pyqtSignal = lambda *a, **k: None
+    pyqtSignal = lambda *a, **k: lambda *args, **kwargs: None
+
+import json
+import urllib.request
 
 from utils.safe_eval import validate_expression
 
@@ -15,16 +49,26 @@ class SettingsWidget(QWidget):
     """Simple settings panel."""
 
     metric_changed = pyqtSignal(str)  # emitted with valid expression
+    log_message = pyqtSignal(str)  # emitted with webhook test result
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.metric_edit = QLineEdit()
         self.metric_edit.setPlaceholderText('sum("conv")/sum("users")')
 
+        self.webhook_edit = QLineEdit()
+        self.webhook_edit.setPlaceholderText('https://example.com/webhook')
+        self.test_button = QPushButton('Test webhook')
+        if hasattr(self.test_button, 'clicked'):
+            self.test_button.clicked.connect(self._on_test_webhook)  # type: ignore
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(QLabel("Custom metric expression"))
         layout.addWidget(self.metric_edit)
+        layout.addWidget(QLabel("Webhook URL"))
+        layout.addWidget(self.webhook_edit)
+        layout.addWidget(self.test_button)
 
         if hasattr(self.metric_edit, "textChanged"):
             self.metric_edit.textChanged.connect(self._on_text_changed)  # type: ignore
@@ -41,3 +85,25 @@ class SettingsWidget(QWidget):
             self.metric_edit.setToolTip("")
             if callable(self.metric_changed):
                 self.metric_changed.emit(text)  # type: ignore
+
+    def _on_test_webhook(self) -> None:
+        url = self.webhook_edit.text()
+        if not url:
+            msg = "Webhook URL is empty"
+        else:
+            data = json.dumps({"text": "test"}).encode()
+            req = urllib.request.Request(
+                url,
+                data=data,
+                headers={"Content-Type": "application/json"},
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=5) as resp:
+                    body = resp.read().decode(errors="ignore")
+                    msg = f"Webhook response {resp.status}: {body}"
+            except Exception as e:
+                msg = f"Webhook error: {e}"
+
+        if callable(self.log_message):
+            self.log_message.emit(msg)  # type: ignore
+

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# PyQt stubs are provided in ui.settings when import fails
+import ui.settings as settings
+from ui.settings import SettingsWidget
+
+
+def test_test_webhook_emits(monkeypatch):
+    recorded = {}
+
+    class Resp:
+        status = 200
+
+        def read(self):
+            return b'ok'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def fake_open(req, timeout=5):
+        recorded['url'] = req.full_url
+        recorded['data'] = req.data
+        return Resp()
+
+    monkeypatch.setattr(settings.urllib.request, 'urlopen', fake_open)
+
+    w = SettingsWidget()
+    w.webhook_edit.text = lambda: 'http://example.com'
+
+    class Capturer:
+        def __init__(self):
+            self.msg = None
+
+        def __call__(self, *a, **k):
+            pass
+
+        def emit(self, m):
+            self.msg = m
+
+    capt = Capturer()
+    w.log_message = capt
+
+    w._on_test_webhook()
+
+    assert recorded['url'] == 'http://example.com'
+    assert b'test' in recorded['data']
+    assert capt.msg.startswith('Webhook response 200')


### PR DESCRIPTION
## Summary
- extend `SettingsWidget` with webhook URL input and test button
- implement POST request and log signal on success or failure
- include stub updates for optional PyQt
- add tests for webhook test logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e22af308832caca179a052bc99bc