### PR TITLE
Add Swagger UI for API docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ setuptools==80.9.0
 tzdata==2025.2
 pytest==8.1.1
 Flask==3.0.3
+flask-swagger-ui==4.11.1

--- a/src/api/analysis.py
+++ b/src/api/analysis.py
@@ -2,11 +2,14 @@
 
 import os
 from flask import Flask, jsonify, request
+from flask_swagger_ui import get_swaggerui_blueprint
 from stats.ab_test import evaluate_abn_test
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
+    swaggerui_blueprint = get_swaggerui_blueprint("/docs", "/spec", config={"app_name": "Analysis API"})
+    app.register_blueprint(swaggerui_blueprint, url_prefix="/docs")
 
     @app.route('/abtest', methods=['POST'])
     def run_abtest():

--- a/src/api/flags.py
+++ b/src/api/flags.py
@@ -1,9 +1,12 @@
 from flask import Flask, jsonify, request
+from flask_swagger_ui import get_swaggerui_blueprint
 from flags import FeatureFlagStore
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
+    swaggerui_blueprint = get_swaggerui_blueprint("/docs", "/spec", config={"app_name": "Flags API"})
+    app.register_blueprint(swaggerui_blueprint, url_prefix="/docs")
     store = FeatureFlagStore()
 
     @app.route('/flags', methods=['GET'])

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("flask_swagger_ui")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from api.analysis import create_app as create_analysis_app
+from api.flags import create_app as create_flags_app
+
+
+def test_analysis_docs_available():
+    app = create_analysis_app()
+    with app.test_client() as client:
+        resp = client.get('/docs/')
+        assert resp.status_code == 200
+
+
+def test_flags_docs_available():
+    app = create_flags_app()
+    with app.test_client() as client:
+        resp = client.get('/docs/')
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- integrate flask-swagger-ui with analysis and flags APIs
- expose docs on `/docs` for each API
- verify swagger UI route via new tests
- add dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e3e7f900832c9806346bb46ab4c8