### PR TITLE
Add Prometheus monitoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest==8.1.1
 Flask==3.0.3
 flask-swagger-ui==4.11.1
 Flask-JWT-Extended==4.6.0
+prometheus_client==0.20.0

--- a/src/api/flags.py
+++ b/src/api/flags.py
@@ -7,6 +7,7 @@ from flask_jwt_extended import (
     jwt_required,
 )
 from flags import FeatureFlagStore
+from metrics import REQUEST_COUNTER, generate_latest, CONTENT_TYPE_LATEST
 
 
 def create_app() -> Flask:
@@ -19,6 +20,15 @@ def create_app() -> Flask:
     )
     app.register_blueprint(swaggerui_blueprint, url_prefix="/docs")
     store = FeatureFlagStore()
+
+    @app.after_request
+    def record_metrics(response):
+        REQUEST_COUNTER.labels(request.path, request.method, response.status_code).inc()
+        return response
+
+    @app.route("/metrics")
+    def metrics():
+        return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
 
     @app.post("/login")
     def login():

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,49 @@
+try:
+    from prometheus_client import Counter, Histogram, Summary, generate_latest, CONTENT_TYPE_LATEST
+except Exception:  # pragma: no cover - fallback stub
+    class _Timer:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class _Metric:
+        def __init__(self, *a, **k):
+            pass
+        def labels(self, *a, **k):
+            return self
+        def inc(self, amount=1):
+            pass
+        def time(self):
+            return _Timer()
+
+    Counter = Histogram = Summary = _Metric  # type: ignore
+    def generate_latest(reg=None):
+        return b""
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+import functools
+
+REQUEST_COUNTER = Counter(
+    "api_requests_total",
+    "Total API requests",
+    ["endpoint", "method", "status"],
+)
+
+FUNCTION_DURATION = Histogram(
+    "heavy_function_seconds",
+    "Time spent in heavy functions",
+    ["function"],
+)
+
+
+def track_time(func):
+    """Decorator to measure execution time using FUNCTION_DURATION."""
+    metric = FUNCTION_DURATION.labels(func.__name__)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with metric.time():
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/src/stats/ab_test.py
+++ b/src/stats/ab_test.py
@@ -2,6 +2,8 @@ import math
 import types
 from typing import List, Optional
 
+from metrics import track_time
+
 try:
     import numpy as np
 except Exception:
@@ -28,6 +30,7 @@ except Exception:
 from webhooks import send_webhook
 
 
+@track_time
 def required_sample_size(p1: float, p2: float, alpha: float, power: float) -> int:
     """Размер выборки на группу (двусторонний тест разности пропорций)."""
     if p1 == p2 or p1 <= 0 or p2 <= 0:
@@ -41,6 +44,7 @@ def required_sample_size(p1: float, p2: float, alpha: float, power: float) -> in
     return max(1, math.ceil(n))
 
 
+@track_time
 def calculate_mde(sample_size: int, alpha: float, power: float, p1: float) -> float:
     """Минимальная обнаруживаемая разница при данных sample_size."""
     if sample_size <= 0 or p1 <= 0:
@@ -136,6 +140,7 @@ def _evaluate_abn_test(
     }
 
 
+@track_time
 def bayesian_analysis(alpha_prior: float, beta_prior: float, users_a: int, conv_a: int, users_b: int, conv_b: int):
     """Bayesian A/B analysis for Bernoulli outcomes."""
     a1 = alpha_prior + conv_a
@@ -150,6 +155,7 @@ def bayesian_analysis(alpha_prior: float, beta_prior: float, users_a: int, conv_
     return prob, x, pdf_a, pdf_b
 
 
+@track_time
 def run_aa_simulation(baseline: float, total_users: int, alpha: float, num_sim: int = 1000) -> float:
     """A/A симуляция, возвращает фактический FPR."""
     ua = total_users // 2
@@ -167,6 +173,7 @@ def run_aa_simulation(baseline: float, total_users: int, alpha: float, num_sim: 
     return float(np.mean(p_vals < alpha))
 
 
+@track_time
 def evaluate_abn_test(
     users_a: int,
     conv_a: int,
@@ -187,6 +194,7 @@ def evaluate_abn_test(
     return res
 
 
+@track_time
 def run_sequential_analysis(ua: int, ca: int, ub: int, cb: int, alpha: float, looks: int = 5, webhook_url: Optional[str] = None):
     """Sequential Pocock method."""
     if looks <= 0:
@@ -212,6 +220,7 @@ def run_sequential_analysis(ua: int, ca: int, ub: int, cb: int, alpha: float, lo
     return steps, pocock_alpha
 
 
+@track_time
 def run_obrien_fleming(ua: int, ca: int, ub: int, cb: int, alpha: float, looks: int = 5, webhook_url: Optional[str] = None):
     """Sequential O'Brien-Fleming method."""
     if looks <= 0:


### PR DESCRIPTION
## Summary
- integrate Prometheus metrics
- track request counts for API endpoints
- expose `/metrics` endpoint
- measure execution time for heavy functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e9ac7f58832ca8423a1c4b71b17d