### PR TITLE
Add JWT refresh tokens and GUI login

### DIFF
--- a/src/api/analysis.py
+++ b/src/api/analysis.py
@@ -5,6 +5,8 @@ from flask import Flask, jsonify, request
 from flask_jwt_extended import (
     JWTManager,
     create_access_token,
+    create_refresh_token,
+    get_jwt_identity,
     jwt_required,
 )
 from flask_swagger_ui import get_swaggerui_blueprint
@@ -35,9 +37,17 @@ def create_app() -> Flask:
     def login():
         data = request.get_json(force=True)
         if data.get("username") == "admin" and data.get("password") == "admin":
-            token = create_access_token(identity="admin")
-            return jsonify(access_token=token)
+            access = create_access_token(identity="admin")
+            refresh = create_refresh_token(identity="admin")
+            return jsonify(access_token=access, refresh_token=refresh)
         return jsonify({"msg": "Bad credentials"}), 401
+
+    @app.post("/refresh")
+    @jwt_required(refresh=True)
+    def refresh():
+        identity = get_jwt_identity()
+        token = create_access_token(identity=identity)
+        return jsonify(access_token=token)
 
     @app.route("/abtest", methods=["POST"])
     @jwt_required()

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -5,5 +5,7 @@ from .ui_mainwindow import ABTestWindow
 if __name__ == "__main__":
     app = QApplication(sys.argv)
     window = ABTestWindow()
-    window.show()
-    sys.exit(app.exec())
+    window.authenticate()
+    if window.token is not None:
+        window.show()
+        sys.exit(app.exec())

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -369,7 +369,7 @@ class ABTestWindow(QMainWindow):
         self.update_ui_text()
         self.sources = []
         self.token = None
-        self._setup_auth()
+        self.refresh_token = None
 
     # ————— История (SQLite) —————
 
@@ -890,7 +890,7 @@ class ABTestWindow(QMainWindow):
         self.clear_history_button.setText(L["clear_history"])
 
     # ----- auth -----
-    def _setup_auth(self):
+    def authenticate(self):
         self._auth_buttons = [
             self.calc_button,
             self.analyze_button,
@@ -910,9 +910,10 @@ class ABTestWindow(QMainWindow):
 
         dlg = LoginDialog(self)
         if dlg.exec():
-            token = self._request_token(*dlg.credentials())
+            token, refresh = self._request_token(*dlg.credentials())
             if token:
                 self.token = token
+                self.refresh_token = refresh
                 for b in self._auth_buttons:
                     b.setEnabled(True)
 
@@ -925,9 +926,10 @@ class ABTestWindow(QMainWindow):
         )
         try:
             with urllib.request.urlopen(req, timeout=5) as resp:
-                return json.loads(resp.read().decode()).get("access_token")
+                js = json.loads(resp.read().decode())
+                return js.get("access_token"), js.get("refresh_token")
         except Exception:
-            return None
+            return None, None
 
     # ————— Обработчики —————
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -15,10 +15,16 @@ def test_login_and_protected_endpoint():
     with app.test_client() as client:
         resp = client.post("/login", json={"username": "admin", "password": "admin"})
         assert resp.status_code == 200
-        token = resp.get_json()["access_token"]
+        data = resp.get_json()
+        token = data["access_token"]
+        refresh = data["refresh_token"]
+
+        resp = client.post("/refresh", headers={"Authorization": f"Bearer {refresh}"})
+        assert resp.status_code == 200
+        new_token = resp.get_json()["access_token"]
 
         resp = client.get("/flags")
         assert resp.status_code == 401
 
-        resp = client.get("/flags", headers={"Authorization": f"Bearer {token}"})
+        resp = client.get("/flags", headers={"Authorization": f"Bearer {new_token}"})
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add refresh token endpoints to Analysis API and Flags API
- require authentication for API usage
- allow GUI login before showing the main window
- store access and refresh tokens in the app
- test refreshing tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f4e3f29c832c9a234256a638a3f6