### PR TITLE
Integrate Swagger UI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ pytest -q
 
 ```
 
+OpenAPI спецификация доступна на `/spec`, интерактивная документация
+Swagger‑UI отображается по адресу `/docs`.
+
 -## Additional Features
 
 - CUPED adjustment and SRM check helpers (SRM warnings shown before analysis)

--- a/src/api/analysis.py
+++ b/src/api/analysis.py
@@ -20,7 +20,12 @@ def create_app() -> Flask:
     jwt = JWTManager(app)
 
     swaggerui_blueprint = get_swaggerui_blueprint(
-        "/docs", "/spec", config={"app_name": "Analysis API"}
+        "/docs",
+        "/spec",
+        config={
+            "app_name": "Analysis API",
+            "supportedSubmitMethods": ["get", "post", "put", "delete"],
+        },
     )
     app.register_blueprint(swaggerui_blueprint, url_prefix="/docs")
 
@@ -69,10 +74,16 @@ def create_app() -> Flask:
         spec = {
             "openapi": "3.0.0",
             "info": {"title": "Analysis API", "version": "1.0"},
+            "servers": [{"url": "/"}],
             "paths": {
+                "/login": {"post": {"responses": {"200": {"description": "Login"}}}},
+                "/refresh": {
+                    "post": {"responses": {"200": {"description": "Refresh"}}}
+                },
                 "/abtest": {
                     "post": {"responses": {"200": {"description": "AB test result"}}}
-                }
+                },
+                "/metrics": {"get": {"responses": {"200": {"description": "Metrics"}}}},
             },
         }
         return jsonify(spec)

--- a/src/api/flags.py
+++ b/src/api/flags.py
@@ -18,7 +18,12 @@ def create_app() -> Flask:
     jwt = JWTManager(app)
 
     swaggerui_blueprint = get_swaggerui_blueprint(
-        "/docs", "/spec", config={"app_name": "Flags API"}
+        "/docs",
+        "/spec",
+        config={
+            "app_name": "Flags API",
+            "supportedSubmitMethods": ["get", "post", "put", "delete"],
+        },
     )
     app.register_blueprint(swaggerui_blueprint, url_prefix="/docs")
     store = FeatureFlagStore()
@@ -60,7 +65,13 @@ def create_app() -> Flask:
         spec = {
             "openapi": "3.0.0",
             "info": {"title": "Flags API", "version": "1.0"},
+            "servers": [{"url": "/"}],
             "paths": {
+                "/login": {"post": {"responses": {"200": {"description": "Login"}}}},
+                "/refresh": {
+                    "post": {"responses": {"200": {"description": "Refresh"}}}
+                },
+                "/metrics": {"get": {"responses": {"200": {"description": "Metrics"}}}},
                 "/flags": {
                     "get": {"responses": {"200": {"description": "List flags"}}},
                     "post": {"responses": {"201": {"description": "Created"}}},


### PR DESCRIPTION
## Summary
- allow interactive Swagger UI docs for both APIs
- expand OpenAPI specs to include all endpoints
- document docs URL in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870f6acf0e8832cb8b72b725046e224