### PR TITLE
Add Prometheus timing to API handlers

### DIFF
--- a/src/api/analysis.py
+++ b/src/api/analysis.py
@@ -11,7 +11,12 @@ from flask_jwt_extended import (
 )
 from flask_swagger_ui import get_swaggerui_blueprint
 from stats.ab_test import evaluate_abn_test
-from metrics import REQUEST_COUNTER, generate_latest, CONTENT_TYPE_LATEST
+from metrics import (
+    REQUEST_COUNTER,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+    track_time,
+)
 
 
 def create_app() -> Flask:
@@ -39,6 +44,7 @@ def create_app() -> Flask:
         return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
 
     @app.post("/login")
+    @track_time
     def login():
         data = request.get_json(force=True)
         if data.get("username") == "admin" and data.get("password") == "admin":
@@ -49,6 +55,7 @@ def create_app() -> Flask:
 
     @app.post("/refresh")
     @jwt_required(refresh=True)
+    @track_time
     def refresh():
         identity = get_jwt_identity()
         token = create_access_token(identity=identity)
@@ -56,6 +63,7 @@ def create_app() -> Flask:
 
     @app.route("/abtest", methods=["POST"])
     @jwt_required()
+    @track_time
     def run_abtest():
         data = request.get_json(force=True)
         res = evaluate_abn_test(

--- a/src/api/flags.py
+++ b/src/api/flags.py
@@ -9,7 +9,12 @@ from flask_jwt_extended import (
     jwt_required,
 )
 from flags import FeatureFlagStore
-from metrics import REQUEST_COUNTER, generate_latest, CONTENT_TYPE_LATEST
+from metrics import (
+    REQUEST_COUNTER,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+    track_time,
+)
 
 
 def create_app() -> Flask:
@@ -38,6 +43,7 @@ def create_app() -> Flask:
         return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
 
     @app.post("/login")
+    @track_time
     def login():
         data = request.get_json(force=True)
         if data.get("username") == "admin" and data.get("password") == "admin":
@@ -48,6 +54,7 @@ def create_app() -> Flask:
 
     @app.post("/refresh")
     @jwt_required(refresh=True)
+    @track_time
     def refresh():
         identity = get_jwt_identity()
         token = create_access_token(identity=identity)
@@ -55,6 +62,7 @@ def create_app() -> Flask:
 
     @app.route("/flags", methods=["GET"])
     @jwt_required()
+    @track_time
     def list_flags():
         flags = store.list_flags()
         return jsonify([flag.__dict__ for flag in flags])
@@ -86,6 +94,7 @@ def create_app() -> Flask:
 
     @app.route("/flags", methods=["POST"])
     @jwt_required()
+    @track_time
     def create_flag():
         data = request.get_json(force=True)
         flag = store.create_flag(
@@ -97,6 +106,7 @@ def create_app() -> Flask:
 
     @app.route("/flags/<name>", methods=["PUT"])
     @jwt_required()
+    @track_time
     def update_flag(name):
         data = request.get_json(force=True)
         flag = store.update_flag(
@@ -108,6 +118,7 @@ def create_app() -> Flask:
 
     @app.route("/flags/<name>", methods=["DELETE"])
     @jwt_required()
+    @track_time
     def delete_flag(name):
         store.delete_flag(name)
         return "", 204


### PR DESCRIPTION
## Summary
- include `track_time` in Analysis/Flags API
- time the login, refresh and API operations using Prometheus metrics

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_6870f952f598832cb84a383d78e8ff75