### PR TITLE
Add Alembic migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,34 @@
+from __future__ import with_statement
+import os
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+# Allow database url override via APP_DB_PATH
+if os.environ.get('APP_DB_PATH'):
+    config.set_main_option('sqlalchemy.url', f"sqlite:///{os.environ['APP_DB_PATH']}")
+
+target_metadata = None
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,35 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'flags',
+        sa.Column('name', sa.String(), primary_key=True),
+        sa.Column('enabled', sa.Integer(), nullable=False),
+        sa.Column('rollout', sa.Float(), nullable=False),
+    )
+    op.create_table(
+        'history',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('timestamp', sa.String()),
+        sa.Column('test', sa.String()),
+        sa.Column('result', sa.String()),
+    )
+    op.create_table(
+        'session_states',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('payload', sa.String()),
+        sa.Column('timestamp', sa.String()),
+    )
+
+
+def downgrade():
+    op.drop_table('session_states')
+    op.drop_table('history')
+    op.drop_table('flags')

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ Flask==3.0.3
 flask-swagger-ui==4.11.1
 Flask-JWT-Extended==4.6.0
 prometheus_client==0.20.0
+SQLAlchemy==2.0.30
+alembic==1.13.1

--- a/src/flags.py
+++ b/src/flags.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 import threading
 import sqlite3
 
+from migrations_runner import run_migrations
+
 @dataclass
 class FeatureFlag:
     """Represents a single feature flag."""
@@ -15,21 +17,8 @@ class FeatureFlagStore:
 
     def __init__(self, db_path: str = "flags.db"):
         self._lock = threading.Lock()
+        run_migrations(db_path)
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
-        self._init_db()
-
-    def _init_db(self) -> None:
-        cur = self._conn.cursor()
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS flags (
-                name TEXT PRIMARY KEY,
-                enabled INTEGER NOT NULL,
-                rollout REAL NOT NULL
-            )
-            """
-        )
-        self._conn.commit()
 
     def create_flag(self, name: str, enabled: bool = False, rollout: float = 100.0) -> FeatureFlag:
         with self._lock:

--- a/src/migrations_runner.py
+++ b/src/migrations_runner.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+
+def _get_db_path(conn: sqlite3.Connection) -> str:
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+        if row:
+            return row[2]
+    except Exception:
+        pass
+    return ""
+
+
+def run_migrations(db: Union[str, sqlite3.Connection]) -> None:
+    """Upgrade DB schema to the latest revision.
+
+    Tries to use Alembic if installed. Falls back to creating tables
+    directly when Alembic or SQLAlchemy are unavailable.
+    """
+    path: str
+    if isinstance(db, sqlite3.Connection):
+        path = _get_db_path(db)
+        conn = db
+    else:
+        path = str(db)
+        conn = sqlite3.connect(path)
+
+    # Try alembic if available
+    try:
+        from alembic.config import Config
+        from alembic import command
+
+        cfg_path = Path(__file__).resolve().parent.parent / "alembic.ini"
+        if cfg_path.exists():
+            cfg = Config(str(cfg_path))
+            cfg.set_main_option("script_location", str(cfg_path.parent / "alembic"))
+            cfg.set_main_option("sqlalchemy.url", f"sqlite:///{path}")
+            command.upgrade(cfg, "head")
+            if not isinstance(db, sqlite3.Connection):
+                conn.close()
+            return
+    except Exception:
+        pass
+
+    # Fallback direct table creation
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS flags (
+            name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL,
+            rollout REAL NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT,
+            test TEXT,
+            result TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_states (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            payload TEXT,
+            timestamp TEXT
+        )
+        """
+    )
+    conn.commit()
+    if not isinstance(db, sqlite3.Connection):
+        conn.close()

--- a/src/ui/history_panel.py
+++ b/src/ui/history_panel.py
@@ -6,6 +6,8 @@ import json
 import sqlite3
 from typing import Any, Dict, List
 
+from migrations_runner import run_migrations
+
 try:
     from PyQt6.QtWidgets import (
         QWidget,
@@ -66,7 +68,7 @@ class HistoryPanel(QWidget):
     def __init__(self, conn: sqlite3.Connection | None = None, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.conn = conn or sqlite3.connect("history.db")
-        self._init_db()
+        run_migrations(self.conn)
 
         self._states: List[Dict[str, Any]] = []
         self._index: int = -1
@@ -98,17 +100,6 @@ class HistoryPanel(QWidget):
         self.load_states()
 
     # ----- database -----
-    def _init_db(self) -> None:
-        c = self.conn.cursor()
-        c.execute(
-            """
-            CREATE TABLE IF NOT EXISTS session_states (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                payload TEXT,
-                timestamp TEXT
-            )"""
-        )
-        self.conn.commit()
 
     def load_states(self) -> None:
         c = self.conn.cursor()

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -2,6 +2,8 @@
 
 import sys
 import sqlite3
+
+from migrations_runner import run_migrations
 import csv
 from typing import Dict
 import json
@@ -377,25 +379,7 @@ class ABTestWindow(QMainWindow):
 
     def _init_history_db(self):
         self.conn = sqlite3.connect("history.db")
-        c = self.conn.cursor()
-        c.execute(
-            """
-            CREATE TABLE IF NOT EXISTS history (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp TEXT,
-                test TEXT,
-                result TEXT
-            )"""
-        )
-        c.execute(
-            """
-            CREATE TABLE IF NOT EXISTS session_states (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                payload TEXT,
-                timestamp TEXT
-            )"""
-        )
-        self.conn.commit()
+        run_migrations(self.conn)
 
     def _load_history(self):
         c = self.conn.cursor()


### PR DESCRIPTION
## Summary
- set up Alembic with config and initial migration
- add a simple migration runner that falls back to raw SQL
- run migrations when feature flags or history are initialized
- install Alembic and SQLAlchemy dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870fc1a9c74832ca7e086b9b31f5fa4