### PR TITLE
Add production Docker build and release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,23 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.prod
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/abtest-tool:${{ github.ref_name }}

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: install production dependencies
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements.prod.txt ./requirements.txt
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+
+# Runtime stage
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY src ./src
+COPY alembic alembic
+COPY alembic.ini .
+COPY plugins plugins
+COPY resources.qss resources.qss
+CMD ["python", "-m", "src.ui.main"]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ Swagger‑UI отображается по адресу `/docs`.
 - Light/Dark theme toggle and sortable history table
 - Simple segmentation helpers and custom metric expressions parsed via AST for security
 
+
+## Docker
+
+Для продакшн-сборки используется multi-stage `Dockerfile.prod`. Он устанавливает
+только необходимые зависимости и запускает приложение на базе образа
+`python:3.11-slim`.
+
+```bash
+docker build -f Dockerfile.prod -t abtest-tool .
+```

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -1,0 +1,17 @@
+numpy==2.3.1
+matplotlib==3.10.3
+plotly==6.2.0
+pillow==10.4.0
+PyQt6==6.9.1
+PyQt6-Qt6==6.9.1
+PyQt6_sip==13.10.2
+python-dateutil==2.9.0.post0
+pytz==2025.2
+setuptools==80.9.0
+tzdata==2025.2
+Flask==3.0.3
+flask-swagger-ui==4.11.1
+Flask-JWT-Extended==4.6.0
+prometheus_client==0.20.0
+SQLAlchemy==2.0.30
+alembic==1.13.1


### PR DESCRIPTION
## Summary
- set up `Dockerfile.prod` for production multi-stage build
- document Docker build instructions in README
- create workflow to push Docker Hub image on version tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871036ecc40832c9e8788c28f47c17c