### PR TITLE
Fix missing scipy dependency

### DIFF
--- a/src/plots/__init__.py
+++ b/src/plots/__init__.py
@@ -1,7 +1,10 @@
 import math
 import numpy as np
 import plotly.graph_objects as go
-from scipy.stats import norm
+
+# ``scipy`` is an optional dependency. ``stats.ab_test`` provides a
+# compatible ``norm`` object with fallbacks when SciPy is unavailable.
+from stats.ab_test import norm
 
 from stats.ab_test import required_sample_size, bayesian_analysis, pocock_alpha_curve
 


### PR DESCRIPTION
## Summary
- fallback to `stats.ab_test.norm` in plotting module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710b685358832c9bd280c6da1239c8