### PR TITLE
Skip GUI authentication

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -7,10 +7,9 @@ def main() -> None:
     """Launch the A/B test GUI application."""
     app = QApplication(sys.argv)
     window = ABTestWindow()
-    window.authenticate()
-    if window.token is not None:
-        window.show()
-        sys.exit(app.exec())
+    # Skip authentication when running locally
+    window.show()
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- simplify `src/ui/main.py` to skip the login dialog and show the main window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68710d1d5578832c95c6f79937c75ab2