### PR TITLE
Update light theme palette

### DIFF
--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -848,7 +848,13 @@ class ABTestWindow(QMainWindow):
         p = QPalette()
         p.setColor(QPalette.ColorRole.Window, Qt.GlobalColor.white)
         p.setColor(QPalette.ColorRole.WindowText, Qt.GlobalColor.black)
+        p.setColor(QPalette.ColorRole.Base, Qt.GlobalColor.white)
+        p.setColor(QPalette.ColorRole.AlternateBase, Qt.GlobalColor.lightGray)
+        p.setColor(QPalette.ColorRole.Text, Qt.GlobalColor.black)
+        p.setColor(QPalette.ColorRole.Button, Qt.GlobalColor.white)
+        p.setColor(QPalette.ColorRole.ButtonText, Qt.GlobalColor.black)
         self.setPalette(p)
+        QApplication.setPalette(p)
 
     def update_ui_text(self):
         L = self.i18n[self.lang]


### PR DESCRIPTION
## Summary
- expand palette colors for the light theme
- apply palette using `QApplication.setPalette`

## Testing
- `pytest -q`
- `pre-commit` *(fails: `pre-commit` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871172f7a3c832ca5943d35eb614717