### PR TITLE
Ensure dialogs inherit parent theme

### DIFF
--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -221,7 +221,14 @@ class AddDataSourceDialog:
                 {"setLayout": lambda *a, **k: None, "setVisible": lambda *a, **k: None},
             )
 
+        self.parent = parent
         self._dialog = QDialog(parent)
+        if parent is not None:
+            try:
+                self._dialog.setPalette(parent.palette())
+                self._dialog.setStyleSheet(parent.styleSheet())
+            except Exception:
+                pass
         try:
             layout = QVBoxLayout_cls(self._dialog)
         except Exception:

--- a/src/ui/wizard.py
+++ b/src/ui/wizard.py
@@ -62,7 +62,14 @@ class QuickABTestWizard(QWizard):
     """Step-by-step wizard for configuring a quick A/B test."""
 
     def __init__(self, parent=None) -> None:
+        self.parent = parent
         super().__init__(parent)
+        if parent is not None:
+            try:
+                self.setPalette(parent.palette())
+                self.setStyleSheet(parent.styleSheet())
+            except Exception:
+                pass
         self.setWindowTitle("Quick AB Test")
 
         self.addPage(self._build_flags_page())


### PR DESCRIPTION
## Summary
- maintain ABTestWindow look and feel in AddDataSourceDialog and QuickABTestWizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687117ef42f8832caeeba06431182130