### PR TITLE
Add icons and use in UI

### DIFF
--- a/src/resources.qss
+++ b/src/resources.qss
@@ -6,7 +6,7 @@ QWidget {
 }
 
 QPushButton {
-    padding: 5px;
+    padding: 5px 5px 5px 25px; /* extra left padding for icons */
     border: 1px solid #888;
     border-radius: 4px;
 }

--- a/src/ui/resources.qrc
+++ b/src/ui/resources.qrc
@@ -1,0 +1,7 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="/resources">
+    <file>resources/run.svg</file>
+    <file>resources/export.svg</file>
+    <file>resources/undo.svg</file>
+</qresource>
+</RCC>

--- a/src/ui/resources/export.svg
+++ b/src/ui/resources/export.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <path d="M32 4v36M20 16l12-12 12 12" stroke="currentColor" stroke-width="4" fill="none"/>
+  <rect x="12" y="32" width="40" height="28" rx="2" ry="2" stroke="currentColor" stroke-width="4" fill="none"/>
+</svg>

--- a/src/ui/resources/run.svg
+++ b/src/ui/resources/run.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <polygon points="16,8 56,32 16,56"/>
+</svg>

--- a/src/ui/resources/undo.svg
+++ b/src/ui/resources/undo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <path d="M24 16L8 32l16 16" stroke="currentColor" stroke-width="4" fill="none"/>
+  <path d="M56 32H8" stroke="currentColor" stroke-width="4" fill="none"/>
+</svg>

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -40,13 +40,24 @@ from PyQt6.QtGui import (
     QAction,
 )
 try:
-    from PyQt6.QtCore import Qt, QDateTime, QEvent
+    from PyQt6.QtGui import QIcon
+except Exception:  # pragma: no cover - optional
+    class QIcon:
+        def __init__(self, *a, **k):
+            pass
+try:
+    from PyQt6.QtCore import Qt, QDateTime, QEvent, QDir
 except Exception:  # pragma: no cover - optional
     from PyQt6.QtCore import Qt, QDateTime  # type: ignore
     class QEvent:
         class Type:
             FocusIn = 0
             FocusOut = 1
+
+    class QDir:
+        @staticmethod
+        def addSearchPath(*a, **k):
+            pass
 
 from .widgets import with_help_label
 
@@ -90,6 +101,10 @@ from plots import (
 )
 from i18n import i18n, detect_language
 import utils
+from pathlib import Path
+
+# Register path prefix for icons used via the Qt resource scheme
+QDir.addSearchPath("resources", str(Path(__file__).resolve().parent / "resources"))
 
 
 def show_error(parent, msg):
@@ -614,6 +629,7 @@ class ABTestWindow(QMainWindow):
 
         # Кнопки анализа
         self.analyze_button = QPushButton()
+        self.analyze_button.setIcon(QIcon(":/resources/run.svg"))
         self.analyze_button.clicked.connect(self._on_analyze)
         self.analyze_button.setToolTip(self.i18n[self.lang]["tooltip.analyze"])
         self.analyze_button.setStatusTip(self.i18n[self.lang]["help.analyze"])
@@ -694,6 +710,7 @@ class ABTestWindow(QMainWindow):
             self.i18n[self.lang]["help.plot_bootstrap"]
         )
         self.save_plot_button = QPushButton()
+        self.save_plot_button.setIcon(QIcon(":/resources/export.svg"))
         self.save_plot_button.clicked.connect(self._save_current_plot)
         self.save_plot_button.setToolTip(self.i18n[self.lang]["tooltip.save_plot"])
         self.save_plot_button.setStatusTip(self.i18n[self.lang]["help.save_plot"])
@@ -721,6 +738,7 @@ class ABTestWindow(QMainWindow):
             self.i18n[self.lang]["help.load_pre_exp"]
         )
         self.clear_button = QPushButton()
+        self.clear_button.setIcon(QIcon(":/resources/undo.svg"))
         self.clear_button.clicked.connect(
             lambda: self.results_text.setHtml("<pre></pre>")
         )


### PR DESCRIPTION
## Summary
- add simple SVG icons and resources.qrc
- register resources path in UI and set icons on buttons
- tweak QPushButton style to add left padding for icons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711fe0aae0832caeb3418e7779c1b1