### PR TITLE
Set font for results browser

### DIFF
--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -883,6 +883,8 @@ class ABTestWindow(QMainWindow):
         right.addLayout(btns)
         if self.alpha_plot_view:
             right.addWidget(self.alpha_plot_view)
+        # Display analysis results using a readable font
+        self.results_text.setStyleSheet("font-size:14pt; font-family:Arial;")
         right.addWidget(self.results_text)
 
         btns2 = QHBoxLayout()


### PR DESCRIPTION
## Summary
- set default font for the results QTextBrowser so analysis output is easier to read

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712a7b3ff0832c82890f54df2c28e7