### PR TITLE
Add config loader

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "flags_db": "flags.db",
+  "history_db": "history.db",
+  "webhook_url": "",
+  "theme": "dark"
+}

--- a/src/flags.py
+++ b/src/flags.py
@@ -4,23 +4,30 @@ import threading
 import sqlite3
 
 from migrations_runner import run_migrations
+from utils.config import config
+
 
 @dataclass
 class FeatureFlag:
     """Represents a single feature flag."""
+
     name: str
     enabled: bool = False
     rollout: float = 100.0  # rollout percentage 0-100
 
+
 class FeatureFlagStore:
     """Thread-safe persistent store for feature flags."""
 
-    def __init__(self, db_path: str = "flags.db"):
+    def __init__(self, db_path: str | None = None):
         self._lock = threading.Lock()
-        run_migrations(db_path)
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        path = db_path or config.get("flags_db", "flags.db")
+        run_migrations(path)
+        self._conn = sqlite3.connect(path, check_same_thread=False)
 
-    def create_flag(self, name: str, enabled: bool = False, rollout: float = 100.0) -> FeatureFlag:
+    def create_flag(
+        self, name: str, enabled: bool = False, rollout: float = 100.0
+    ) -> FeatureFlag:
         with self._lock:
             cur = self._conn.cursor()
             cur.execute("SELECT 1 FROM flags WHERE name=?", (name,))
@@ -35,7 +42,13 @@ class FeatureFlagStore:
             self._conn.commit()
             return FeatureFlag(name=name, enabled=enabled, rollout=rollout)
 
-    def update_flag(self, name: str, *, enabled: Optional[bool] = None, rollout: Optional[float] = None) -> FeatureFlag:
+    def update_flag(
+        self,
+        name: str,
+        *,
+        enabled: Optional[bool] = None,
+        rollout: Optional[float] = None
+    ) -> FeatureFlag:
         with self._lock:
             cur = self._conn.cursor()
             cur.execute("SELECT enabled, rollout FROM flags WHERE name=?", (name,))
@@ -70,7 +83,9 @@ class FeatureFlagStore:
             cur = self._conn.cursor()
             cur.execute("SELECT name, enabled, rollout FROM flags")
             rows = cur.fetchall()
-            return [FeatureFlag(name=r[0], enabled=bool(r[1]), rollout=r[2]) for r in rows]
+            return [
+                FeatureFlag(name=r[0], enabled=bool(r[1]), rollout=r[2]) for r in rows
+            ]
 
     def delete_flag(self, name: str) -> None:
         with self._lock:

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@
 import plugin_loader
 
 from ui.main import main
+from utils.config import config
 
 if __name__ == "__main__":
-    main()
+    main(config)

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -8,9 +8,10 @@ if __package__ is None:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from ui.ui_mainwindow import ABTestWindow
+from utils.config import config
 
 
-def main() -> None:
+def main(cfg=config) -> None:
     """Launch the A/B test GUI application."""
     app = QApplication(sys.argv)
 
@@ -24,7 +25,7 @@ def main() -> None:
         translator.load(str(translations_dir / "app_en.qm"))
         app.installTranslator(translator)
 
-    window = ABTestWindow()
+    window = ABTestWindow(cfg)
     # Skip authentication when running locally
     window.show()
     sys.exit(app.exec())

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,0 +1,42 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+
+class Config:
+    """Simple config loader with env var overrides."""
+
+    def __init__(self, path: str | Path = "config.json") -> None:
+        self._data: Dict[str, Any] = {}
+        self.path = Path(path)
+        self.load(self.path)
+
+    def load(self, path: str | Path | None = None) -> None:
+        p = Path(path or self.path)
+        if not p.exists():
+            return
+        if p.suffix in {".yaml", ".yml"}:
+            if yaml is None:
+                return
+            with p.open("r", encoding="utf-8") as f:
+                self._data = yaml.safe_load(f) or {}
+        elif p.suffix == ".json":
+            with p.open("r", encoding="utf-8") as f:
+                self._data = json.load(f) or {}
+        else:
+            raise ValueError("Unsupported config format")
+
+    def get(self, key: str, default: Any = None) -> Any:
+        env_key = key.upper()
+        if env_key in os.environ:
+            return os.environ[env_key]
+        return self._data.get(key, default)
+
+
+config = Config()


### PR DESCRIPTION
## Summary
- create JSON-based config with db paths, webhook and theme
- load configuration from utils.config with env overrides
- read config values in FeatureFlagStore and UI classes
- inject config into main entrypoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687627db3250832c9aa8c13e95742f55