### PR TITLE
Add run-analysis CLI and entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name="abtest-tool",
+    version="0.1.0",
+    py_modules=["cli"],
+    package_dir={"": "src"},
+    entry_points={"console_scripts": ["abtest-tool=cli:main"]},
+)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,49 @@
+import argparse
+import json
+from typing import List
+
+from stats.ab_test import evaluate_abn_test
+
+
+def _run_analysis(args: argparse.Namespace) -> None:
+    """Run A/B test analysis from a JSON source file."""
+    with open(args.source, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    res = evaluate_abn_test(
+        data["users_a"],
+        data["conv_a"],
+        data["users_b"],
+        data["conv_b"],
+        alpha=data.get("alpha", 0.05),
+    )
+    if args.output_format == "json":
+        print(json.dumps(res))
+    else:
+        for k, v in res.items():
+            print(f"{k}: {v}")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="abtest-tool")
+    subparsers = parser.add_subparsers(dest="command")
+
+    pa = subparsers.add_parser("run-analysis", help="Run A/B test analysis")
+    pa.add_argument("--source", required=True, help="Path to JSON data file")
+    pa.add_argument("--flags", nargs="*", default=[], help="Optional flags")
+    pa.add_argument(
+        "--output-format",
+        choices=["json", "text"],
+        default="json",
+        help="Output format",
+    )
+    pa.set_defaults(func=_run_analysis)
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,30 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cli
+
+
+def test_run_analysis_json(tmp_path, capsys):
+    data = {"users_a": 100, "conv_a": 10, "users_b": 120, "conv_b": 30}
+    src_file = tmp_path / "data.json"
+    src_file.write_text(json.dumps(data))
+
+    cli.main(["run-analysis", "--source", str(src_file), "--output-format", "json"])
+    out = capsys.readouterr().out.strip()
+    res = json.loads(out)
+    assert "p_value_ab" in res
+    assert "significant_ab" in res
+
+
+def test_run_analysis_text(tmp_path, capsys):
+    data = {"users_a": 50, "conv_a": 5, "users_b": 50, "conv_b": 8}
+    src_file = tmp_path / "data.json"
+    src_file.write_text(json.dumps(data))
+
+    cli.main(["run-analysis", "--source", str(src_file), "--output-format", "text"])
+    out = capsys.readouterr().out
+    assert "p_value_ab" in out
+


### PR DESCRIPTION
## Summary
- add `cli.py` with `run-analysis` command via argparse
- expose `abtest-tool` entrypoint in `setup.py` and minimal `pyproject.toml`
- test CLI behaviour in `tests/test_cli.py`

## Testing
- `pytest tests/test_cli.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687629f0ff78832cb1a760cc6369c970