### PR TITLE
Add Sphinx documentation with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx
+      - name: Build docs
+        run: |
+          make -C docs html
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_build/html
+      - uses: actions/deploy-pages@v2

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,14 @@
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+.PHONY: help clean html
+
+help:
+	@$(SPHINXBUILD) -M help $(SOURCEDIR) $(BUILDDIR)
+
+clean:
+	rm -rf $(BUILDDIR)
+
+html:
+	@$(SPHINXBUILD) -M html $(SOURCEDIR) $(BUILDDIR)

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+.. automodule:: flags
+   :members:
+
+.. automodule:: logic
+   :members:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../src'))
+
+project = 'ABTest Tool'
+author = 'Your Name'
+release = '0.1'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -1,0 +1,24 @@
+Cookbook
+========
+
+Пример создания и использования feature flag:
+
+.. code-block:: python
+
+   from flags import FeatureFlagStore
+
+   store = FeatureFlagStore()
+   store.create_flag('new_ui', enabled=False)
+   flag = store.get_flag('new_ui')
+   print(flag)
+   store.close()
+
+Пример построения графика доверительных интервалов:
+
+.. code-block:: python
+
+   from plots import plot_confidence_intervals
+
+   data_a = [1, 2, 3]
+   data_b = [3, 4, 5]
+   plot_confidence_intervals(data_a, data_b)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,10 @@
+Welcome to ABTest Tool's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   quickstart
+   api_reference
+   cookbook

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,14 @@
+Quickstart
+==========
+
+Установка и первый запуск:
+
+.. code-block:: bash
+
+   git clone https://github.com/Nhimphu/abtest-tool.git
+   cd abtest-tool
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   python src/ui/main.py
+


### PR DESCRIPTION
## Summary
- initialize Sphinx docs in `docs/`
- add Quickstart, API reference and Cookbook sections
- configure autodoc in `conf.py`
- add workflow to build docs and deploy to GitHub Pages

## Testing
- `pytest -q`
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762be40940832caa4b49bee3247576