### PR TITLE
Add Sphinx docs setup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,8 +2,8 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../src'))
 
-project = 'ABTest Tool'
-author = 'Your Name'
+project = 'abtest-tool'
+author = 'Nhimphu'
 release = '0.1'
 
 extensions = [

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -17,8 +17,10 @@ Cookbook
 
 .. code-block:: python
 
-   from plots import plot_confidence_intervals
+    from stats.ab_test import run_sequential_analysis
 
-   data_a = [1, 2, 3]
-   data_b = [3, 4, 5]
-   plot_confidence_intervals(data_a, data_b)
+    steps, pocock_alpha = run_sequential_analysis(
+        ua=1000, ca=50, ub=1000, cb=60, alpha=0.05, looks=5
+    )
+    for step in steps:
+        print(step["p_value_ab"])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,9 @@ Welcome to ABTest Tool's documentation!
    quickstart
    api_reference
    cookbook
+
+The documentation is structured into three main sections:
+
+* **Quickstart** – пошаговая инструкция по установке и первому запуску.
+* **API Reference** – автоматически генерируется из docstring‑комментариев.
+* **Cookbook** – готовые примеры работы с feature‑флагами и последовательными тестами.


### PR DESCRIPTION
## Summary
- configure Sphinx project for **abtest-tool**
- document structure in `index.rst`
- add sequential test example to the Cookbook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763c8f0988832ca8b3eaa2ca15f529