### PR TITLE
Add centralized logger

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -1,0 +1,13 @@
+version: 1
+formatters:
+  simple:
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: simple
+    stream: ext://sys.stdout
+root:
+  level: INFO
+  handlers: [console]

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -1,7 +1,14 @@
 import sys
+import logging
+import logging.config
 from pathlib import Path
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtCore import QTranslator, QLocale
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
 
 # Allow running this module directly without setting PYTHONPATH
 if __package__ is None:
@@ -13,6 +20,14 @@ from utils.config import config
 
 def main(cfg=config) -> None:
     """Launch the A/B test GUI application."""
+    cfg_path = Path(__file__).resolve().parents[1] / "logging.yaml"
+    if cfg_path.exists() and yaml is not None:
+        with cfg_path.open("r", encoding="utf-8") as f:
+            logging.config.dictConfig(yaml.safe_load(f))
+    else:  # pragma: no cover - fallback if yaml not available
+        logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
     app = QApplication(sys.argv)
 
     translator = QTranslator()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,30 +1,36 @@
 import json
 import os
 import sys
+import logging
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 import cli
 
 
-def test_run_analysis_json(tmp_path, capsys):
+def _setup_caplog(caplog):
+    caplog.set_level(logging.INFO)
+
+
+def test_run_analysis_json(tmp_path, caplog):
+    _setup_caplog(caplog)
     data = {"users_a": 100, "conv_a": 10, "users_b": 120, "conv_b": 30}
     src_file = tmp_path / "data.json"
     src_file.write_text(json.dumps(data))
 
     cli.main(["run-analysis", "--source", str(src_file), "--output-format", "json"])
-    out = capsys.readouterr().out.strip()
-    res = json.loads(out)
+    res = json.loads(caplog.records[-1].message)
     assert "p_value_ab" in res
     assert "significant_ab" in res
 
 
-def test_run_analysis_text(tmp_path, capsys):
+def test_run_analysis_text(tmp_path, caplog):
+    _setup_caplog(caplog)
     data = {"users_a": 50, "conv_a": 5, "users_b": 50, "conv_b": 8}
     src_file = tmp_path / "data.json"
     src_file.write_text(json.dumps(data))
 
     cli.main(["run-analysis", "--source", str(src_file), "--output-format", "text"])
-    out = capsys.readouterr().out
+    out = caplog.text
     assert "p_value_ab" in out
 


### PR DESCRIPTION
## Summary
- centralize logging configuration via `logging.yaml`
- configure logging before GUI initialization
- log CLI output instead of printing
- update CLI tests to check logged output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764eb7b3b0832cb7e49874b226fac7