### PR TITLE
Add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Update Changelog and Release
+name: Release
 
 on:
   push:
@@ -6,35 +6,46 @@ on:
       - 'v*.*.*'
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-root
+      - name: Build package
+        run: poetry build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
 
-      - name: Update CHANGELOG
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          PREV_TAG=$(git describe --tags --abbrev=0 "$TAG"^ 2>/dev/null || echo "")
-          DATE=$(date +%Y-%m-%d)
-          echo "## [$TAG] - $DATE" > new_changelog
-          if [ -n "$PREV_TAG" ]; then
-            git log "$PREV_TAG"..HEAD --pretty=format:"- %s" >> new_changelog
-          else
-            git log --pretty=format:"- %s" >> new_changelog
-          fi
-          echo >> new_changelog
-          cat CHANGELOG.md >> new_changelog
-          mv new_changelog CHANGELOG.md
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.prod
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/abtest-tool:${{ github.ref_name }}
 
-      - name: Commit CHANGELOG
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add CHANGELOG.md
-          git commit -m "Update CHANGELOG for $TAG" || echo "no changes"
-          git push
-
-      - name: Create Release
+  release:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create GitHub Release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace release workflow with automation
- build & publish with poetry and Docker
- create GitHub Release using CHANGELOG

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687654ec0cdc832c9750ab37c4dbf2cd