### PR TITLE
Fix bayesian plugin handling

### DIFF
--- a/src/plugin_loader.py
+++ b/src/plugin_loader.py
@@ -1,5 +1,6 @@
 """Utility to automatically load optional plugins."""
 import importlib
+import logging
 import os
 import sys
 from types import ModuleType
@@ -12,6 +13,7 @@ if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
 _loaded: Dict[str, ModuleType] = {}
+logger = logging.getLogger(__name__)
 
 
 def load_plugins() -> None:
@@ -27,7 +29,8 @@ def load_plugins() -> None:
             continue
         try:
             mod = importlib.import_module(mod_name)
-        except Exception:
+        except Exception as exc:  # pragma: no cover - optional plugins may fail
+            logger.exception("Failed to import plugin %s", mod_name)
             continue
         _loaded[name] = mod
 

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -678,9 +678,11 @@ class ABTestWindow(QMainWindow):
         self.conf_button.setToolTip(self.tr("Plot confidence intervals"))
         self.conf_button.setStatusTip(self.tr("Plot confidence intervals"))
         self.bayes_button = QPushButton()
-        self.bayes_button.clicked.connect(self._on_run_bayes)
+        self.bayes_button.clicked.connect(self._on_bayes)
         self.bayes_button.setToolTip(self.tr("Run Bayesian analysis"))
         self.bayes_button.setStatusTip(self.tr("Run Bayesian analysis"))
+        if not plugin_loader.get_plugin("bayesian"):
+            self.bayes_button.setEnabled(False)
         self.aa_button = QPushButton()
         self.aa_button.clicked.connect(self._on_run_aa)
         self.aa_button.setToolTip(self.tr("Run A/A simulation"))
@@ -1292,16 +1294,13 @@ class ABTestWindow(QMainWindow):
         except Exception as e:
             show_error(self, str(e))
 
-    def _on_run_bayes(self):
+    def _on_bayes(self):
         try:
             ua, ca = int(self.users_A_var.text()), int(self.conv_A_var.text())
             ub, cb = int(self.users_B_var.text()), int(self.conv_B_var.text())
             a0 = self.prior_alpha_spin.value()
             b0 = self.prior_beta_spin.value()
-            plug = plugin_loader.get_plugin("bayesian")
-            if not plug or not hasattr(plug, "bayesian_analysis"):
-                raise ImportError("Bayesian analysis plugin not available")
-            prob, x, pa, pb = plug.bayesian_analysis(a0, b0, ua, ca, ub, cb)
+            prob, x, pa, pb = bayesian_analysis(a0, b0, ua, ca, ub, cb)
             tr = getattr(self, "tr", lambda x: x)
             html = f"<pre>{tr('P(B>A)')} = {prob:.2%}</pre>"
             self.results_text.setHtml(html)
@@ -1311,7 +1310,7 @@ class ABTestWindow(QMainWindow):
             w = PlotWindow(self)
             w.display_plot(fig)
         except Exception as e:
-            show_error(self, str(e))
+            QMessageBox.critical(self, self.tr("Error"), str(e))
 
     def _on_run_aa(self):
         try:

--- a/tests/test_ui_bayes.py
+++ b/tests/test_ui_bayes.py
@@ -152,11 +152,11 @@ def test_ui_renders_bayes(monkeypatch):
         results_text = types.SimpleNamespace(setHtml=lambda html: called.setdefault('html', html))
         _add_history = lambda *a, **k: None
 
-    monkeypatch.setattr(plugin_loader, 'get_plugin', lambda name: types.SimpleNamespace(bayesian_analysis=lambda *a: (0.6, [], [], [])))
+    monkeypatch.setattr(ui_mainwindow, 'bayesian_analysis', lambda *a, **k: (0.6, [], [], []))
     monkeypatch.setattr(ui_mainwindow, 'plot_bayesian_posterior', lambda *a, **k: 'fig')
     monkeypatch.setattr(ui_mainwindow, 'PlotWindow', lambda *a, **k: types.SimpleNamespace(display_plot=lambda f: called.setdefault('fig', f)))
 
-    ui_mainwindow.ABTestWindow._on_run_bayes(DummyWindow())
+    ui_mainwindow.ABTestWindow._on_bayes(DummyWindow())
 
     assert '60' in called['html']
     assert called['fig'] == 'fig'


### PR DESCRIPTION
## Summary
- log plugin import errors in `plugin_loader`
- disable Bayesian Analysis button if plugin missing
- call `bayesian_analysis` from new `_on_bayes` handler and show QMessageBox errors
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687667a79030832c8238b659d7a0bfcb