### PR TITLE
Improve tutorial tab with step‑by‑step guide

### DIFF
--- a/src/ui/resources/tutorial/step_export.svg
+++ b/src/ui/resources/tutorial/step_export.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="black">
+    Step 4: Export Reports
+  </text>
+</svg>

--- a/src/ui/resources/tutorial/step_flags.svg
+++ b/src/ui/resources/tutorial/step_flags.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="black">
+    Step 1: Flags &amp; Metrics
+  </text>
+</svg>

--- a/src/ui/resources/tutorial/step_launch.svg
+++ b/src/ui/resources/tutorial/step_launch.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="black">
+    Step 2: Launch Tests
+  </text>
+</svg>

--- a/src/ui/resources/tutorial/step_results.svg
+++ b/src/ui/resources/tutorial/step_results.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="black">
+    Step 3: View Results
+  </text>
+</svg>

--- a/src/ui/resources/tutorial/step_theme.svg
+++ b/src/ui/resources/tutorial/step_theme.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="black">
+    Step 5: Theme &amp; Language
+  </text>
+</svg>

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -1432,15 +1432,49 @@ class ABTestWindow(QMainWindow):
             show_error(self, str(e))
 
     def show_tutorial(self):
-        QMessageBox.information(
-            self,
-            self.tr("Tutorial"),
-            "🔹 Слайдеры CR, uplift, α, power\n"
-            "🔹 Поля A/B/C\n"
-            "🔹 Bayesian с priors\n"
-            "🔹 ROI встроен\n"
-            "🔹 История с экспортом",
+        try:
+            from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QPushButton
+        except Exception:
+            QMessageBox.information(
+                self,
+                self.tr("Tutorial"),
+                self.tr(
+                    "Use the sliders and fields to configure your A/B test. "
+                    "Check README for full instructions."
+                ),
+            )
+            return
+
+        dlg = QDialog(self)
+        dlg.setWindowTitle(self.tr("Tutorial"))
+        layout = QVBoxLayout(dlg)
+        browser = QTextBrowser()
+        html = (
+            f"<h2>{self.tr('Step 1: select flags and metrics')}</h2>"
+            f"<p>{self.tr('Choose a feature flag and primary metric. Fill group data in the A/B/C fields.')}</p>"
+            f"<img src='resources:tutorial/step_flags.svg' width='500'>"
+            f"<h2>{self.tr('Step 2: launch analysis')}</h2>"
+            f"<p>{self.tr('Run A/B/n or enable sequential, CUPED, SRM and Bayesian options in the Advanced block.')}</p>"
+            f"<img src='resources:tutorial/step_launch.svg' width='500'>"
+            f"<h2>{self.tr('Step 3: read results and history')}</h2>"
+            f"<p>{self.tr('Results appear below with a history table to store previous runs.')}</p>"
+            f"<img src='resources:tutorial/step_results.svg' width='500'>"
+            f"<h2>{self.tr('Step 4: export reports')}</h2>"
+            f"<p>{self.tr('Use the File menu to export PDF, Excel, CSV or notebooks.')}</p>"
+            f"<img src='resources:tutorial/step_export.svg' width='500'>"
+            f"<h2>{self.tr('Step 5: switch theme and language')}</h2>"
+            f"<p>{self.tr('Buttons on the right of the menu bar toggle dark/light mode and translations.')}</p>"
+            f"<img src='resources:tutorial/step_theme.svg' width='500'>"
+            f"<p>{self.tr('Additional tools include ROI calculation and a quick AB wizard.')}</p>"
         )
+        browser.setHtml(html)
+        layout.addWidget(browser)
+        close_btn = QPushButton(self.tr("Close"))
+        if hasattr(close_btn, "clicked"):
+            close_btn.clicked.connect(dlg.accept)  # type: ignore
+        layout.addWidget(close_btn)
+        if hasattr(dlg, "exec"):
+            dlg.exec()
 
     def toggle_theme(self):
         if getattr(self, "is_dark", True):


### PR DESCRIPTION
## Summary
- replace simple message box with a detailed tutorial dialog
- show screenshots and explanations in multiple steps
- add placeholder images for the tutorial

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767237ec70832cb5b483b67cdb3ae5