### PR TITLE
Add widget styling and fix light theme

### DIFF
--- a/src/resources.qss
+++ b/src/resources.qss
@@ -49,3 +49,13 @@ QToolTip {
     color: #000000;
     border: 1px solid #000;
 }
+QWidget#resultsPanel {
+    background: white;
+    border: 1px solid #cccccc;
+}
+
+QGroupBox {
+    background: #f9f9f9;
+    border: 1px solid #aaaaaa;
+    margin: 5px;
+}

--- a/src/ui/ui_mainwindow.py
+++ b/src/ui/ui_mainwindow.py
@@ -1102,8 +1102,12 @@ class ABTestWindow(QMainWindow):
         # Всплывающие подсказки
         p.setColor(QPalette.ColorRole.ToolTipBase, Qt.GlobalColor.black)
         p.setColor(QPalette.ColorRole.ToolTipText, Qt.GlobalColor.black)
-        # Применение
-        QApplication.setPalette(p)
+        # Применение палитры ко всем существующим виджетам
+        app = QApplication.instance()
+        if app:
+            app.setPalette(p)
+            for w in app.allWidgets():
+                w.setPalette(p)
         # Сброс custom stylesheet, если есть
         self.setStyleSheet("")
 


### PR DESCRIPTION
## Summary
- tweak QGroupBox and results panel styles
- apply light theme palette to all widgets for consistent color updates

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687676a20900832cb59958e2c3094f1d