### PR TITLE
Add DWH connectors loader & plugin registry

### DIFF
--- a/plugins/connectors.py
+++ b/plugins/connectors.py
@@ -6,6 +6,7 @@ when a particular connector is used.
 """
 
 from typing import Any, Dict, List
+from utils.connectors import register_connector
 
 
 class BigQueryConnector:
@@ -53,5 +54,8 @@ class RedshiftConnector:
     def close(self) -> None:
         self._conn.close()
 
+
+register_connector("bigquery", BigQueryConnector)
+register_connector("redshift", RedshiftConnector)
 
 __all__ = ["BigQueryConnector", "RedshiftConnector"]

--- a/src/utils/connectors.py
+++ b/src/utils/connectors.py
@@ -1,32 +1,135 @@
-"""Lightweight wrappers delegating to optional connector plugins."""
+"""Lightweight wrappers and helpers for optional DWH connector plugins."""
 
-from typing import Any, Dict, List
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Type
+
+try:  # UI message boxes are optional
+    from PyQt6.QtWidgets import QMessageBox
+except Exception:  # pragma: no cover - optional dependency
+    QMessageBox = None  # type: ignore
+
+# Registry for dynamically added connectors
+_CONNECTORS: Dict[str, Type] = {}
+
+
+def register_connector(name: str, cls: Type) -> None:
+    """Register a connector class under ``name``."""
+
+    _CONNECTORS[name.lower()] = cls
+
+
+def _missing_class(name: str) -> Type:
+    class MissingConnector:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise ImportError(f"{name} plugin not available")
+
+    return MissingConnector
+
 
 import plugin_loader
 
+# Ensure plugins are loaded before accessing the registry
+plugin_loader.load_plugins()
+
+# Plugins may register their connectors during import
 _plug = plugin_loader.get_plugin("connectors")
+if _plug:
+    for attr in dir(_plug):
+        obj = getattr(_plug, attr)
+        if isinstance(obj, type) and attr.endswith("Connector"):
+            register_connector(attr.replace("Connector", ""), obj)
 
-if _plug and hasattr(_plug, "BigQueryConnector"):
-    BigQueryConnector = _plug.BigQueryConnector  # type: ignore
-else:
-
-    class BigQueryConnector:
-        """Fallback that signals missing plugin."""
-
-        def __init__(self, *_: Any, **__: Any) -> None:
-            raise ImportError("BigQueryConnector plugin not available")
-
-
-if _plug and hasattr(_plug, "RedshiftConnector"):
-    RedshiftConnector = _plug.RedshiftConnector  # type: ignore
-else:
-
-    class RedshiftConnector:
-        """Fallback that signals missing plugin."""
-
-        def __init__(self, *_: Any, **__: Any) -> None:
-            raise ImportError("RedshiftConnector plugin not available")
+# Ensure registry is populated if plugins were loaded lazily
+if "bigquery" not in _CONNECTORS or "redshift" not in _CONNECTORS:
+    plugin_loader.load_plugins()
+    _plug = plugin_loader.get_plugin("connectors")
+    if _plug:
+        for attr in dir(_plug):
+            obj = getattr(_plug, attr)
+            if isinstance(obj, type) and attr.endswith("Connector"):
+                register_connector(attr.replace("Connector", ""), obj)
 
 
-__all__ = ["BigQueryConnector", "RedshiftConnector"]
+class _ConnectorProxy:
+    _name: str
+
+    def __new__(cls, *args: Any, **kwargs: Any):
+        real_cls = _CONNECTORS.get(cls._name)
+        if real_cls is None:
+            raise ImportError(f"{cls.__name__} plugin not available")
+        return real_cls(*args, **kwargs)
+
+
+class BigQueryConnector(_ConnectorProxy):
+    _name = "bigquery"
+
+
+class RedshiftConnector(_ConnectorProxy):
+    _name = "redshift"
+
+
+def _show_error(msg: str) -> None:
+    if QMessageBox and hasattr(QMessageBox, "critical"):
+        QMessageBox.critical(None, "Error", msg)
+
+
+def load_from_bigquery(query: str) -> List[Dict[str, Any]]:
+    """Execute ``query`` in BigQuery and return results.
+
+    Connection parameters are taken from the ``BQ_PROJECT`` and
+    ``BQ_CREDENTIALS`` environment variables. Any connection errors are
+    displayed via :class:`QMessageBox` when available.
+    """
+
+    project = os.getenv("BQ_PROJECT")
+    creds = os.getenv("BQ_CREDENTIALS")
+    try:
+        if not project or not creds:
+            raise ValueError("BigQuery credentials not provided")
+        conn = BigQueryConnector(project, creds)
+        rows = conn.query(query)
+        if hasattr(conn, "close"):
+            conn.close()
+        return rows
+    except Exception as exc:  # pragma: no cover - optional deps
+        _show_error(f"BigQuery error: {exc}")
+        return []
+
+
+def load_from_redshift(sql: str) -> List[Dict[str, Any]]:
+    """Execute ``sql`` in Redshift and return results.
+
+    Connection parameters are read from the ``RS_HOST``, ``RS_PORT``,
+    ``RS_DATABASE``, ``RS_USER`` and ``RS_PASSWORD`` environment variables.
+    Errors are communicated via :class:`QMessageBox` when available.
+    """
+
+    host = os.getenv("RS_HOST")
+    port = int(os.getenv("RS_PORT", "5439"))
+    database = os.getenv("RS_DATABASE")
+    user = os.getenv("RS_USER")
+    password = os.getenv("RS_PASSWORD")
+    try:
+        if not all([host, database, user, password]):
+            raise ValueError("Redshift credentials not provided")
+        conn = RedshiftConnector(host=host, port=port, database=database, user=user, password=password)
+        rows = conn.query(sql)
+        if hasattr(conn, "close"):
+            conn.close()
+        return rows
+    except Exception as exc:  # pragma: no cover - optional deps
+        _show_error(f"Redshift error: {exc}")
+        return []
+
+
+__all__ = [
+    "register_connector",
+    "BigQueryConnector",
+    "RedshiftConnector",
+    "load_from_bigquery",
+    "load_from_redshift",
+]
+
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -4,7 +4,12 @@ import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from utils.connectors import BigQueryConnector, RedshiftConnector
+from utils.connectors import (
+    BigQueryConnector,
+    RedshiftConnector,
+    load_from_bigquery,
+    load_from_redshift,
+)
 
 
 def test_bigquery_connector_queries(monkeypatch):
@@ -46,11 +51,71 @@ def test_redshift_connector_queries(monkeypatch):
     class DummyConn:
         def cursor(self):
             return DummyCursor()
+        def close(self):
+            pass
     rs_mod = types.ModuleType('redshift_connector')
     rs_mod.connect = lambda **kw: DummyConn()
     monkeypatch.setitem(sys.modules, 'redshift_connector', rs_mod)
 
     conn = RedshiftConnector('h', 5439, 'db', 'u', 'p')
     rows = conn.query('SELECT 1')
+    assert called['sql'] == 'SELECT 1'
+    assert rows == [{'a': 2}]
+
+
+def test_load_from_bigquery(monkeypatch):
+    called = {}
+    class DummyResult:
+        def result(self):
+            return [types.SimpleNamespace(items=lambda: [('a', 1)])]
+    class DummyClient:
+        def query(self, sql):
+            called['sql'] = sql
+            return DummyResult()
+
+    bigquery_mod = types.ModuleType('google.cloud.bigquery')
+    bigquery_mod.Client = types.SimpleNamespace(from_service_account_json=lambda p, project=None: DummyClient())
+    cloud_mod = types.ModuleType('google.cloud')
+    cloud_mod.bigquery = bigquery_mod
+    monkeypatch.setitem(sys.modules, 'google', types.ModuleType('google'))
+    monkeypatch.setitem(sys.modules, 'google.cloud', cloud_mod)
+    monkeypatch.setitem(sys.modules, 'google.cloud.bigquery', bigquery_mod)
+
+    monkeypatch.setenv('BQ_PROJECT', 'p')
+    monkeypatch.setenv('BQ_CREDENTIALS', 'c.json')
+
+    rows = load_from_bigquery('SELECT 1')
+    assert called['sql'] == 'SELECT 1'
+    assert rows == [{'a': 1}]
+
+
+def test_load_from_redshift(monkeypatch):
+    called = {}
+    class DummyCursor:
+        description = [('a',)]
+        def execute(self, sql):
+            called['sql'] = sql
+        def fetchall(self):
+            return [(2,)]
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+        def close(self):
+            pass
+    rs_mod = types.ModuleType('redshift_connector')
+    rs_mod.connect = lambda **kw: DummyConn()
+    monkeypatch.setitem(sys.modules, 'redshift_connector', rs_mod)
+
+    monkeypatch.setenv('RS_HOST', 'h')
+    monkeypatch.setenv('RS_PORT', '5439')
+    monkeypatch.setenv('RS_DATABASE', 'db')
+    monkeypatch.setenv('RS_USER', 'u')
+    monkeypatch.setenv('RS_PASSWORD', 'p')
+
+    rows = load_from_redshift('SELECT 1')
     assert called['sql'] == 'SELECT 1'
     assert rows == [{'a': 2}]


### PR DESCRIPTION
## Summary
- implement dynamic connector registration and loader helpers
- register plugin connectors
- extend connector tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767dd93480832c833bae439d40bd94