### PR TITLE
Fix tooltip translations

### DIFF
--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -78,11 +78,11 @@ class SettingsWidget(QWidget):
         try:
             validate_expression(text)
         except Exception as e:  # ValueError
-            self.metric_edit.setToolTip(str(e))
+            self.metric_edit.setToolTip(self.tr(str(e)))
             if hasattr(QToolTip, "showText"):
                 QToolTip.showText(self.metric_edit.mapToGlobal(self.metric_edit.rect().bottomLeft()), str(e))
         else:
-            self.metric_edit.setToolTip("")
+            self.metric_edit.setToolTip(self.tr(""))
             if callable(self.metric_changed):
                 self.metric_changed.emit(text)  # type: ignore
 

--- a/src/ui/widgets/help.py
+++ b/src/ui/widgets/help.py
@@ -40,7 +40,7 @@ class HelpIcon(QLabel):
             self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         except Exception:
             pass
-        self.setToolTip(text)
+        self.setToolTip(self.tr(text))
 
 
 def with_help_label(label: QLabel, help_text: str) -> QWidget:


### PR DESCRIPTION
## Summary
- wrap tooltip texts in translation calls

## Testing
- `poetry run pytest -q`
- `pylupdate6 src/ui/ui_mainwindow.py src/ui/wizard.py src/ui/main.py -ts translations/app_en.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778f055f04832cb9d99567756012f6