### PR TITLE
feat(stats): add binomial/continuous/ratio engines with CIs (Wilson/Newcombe, Welch, Fieller, bootstrap)

### DIFF
--- a/src/abtest_core/__init__.py
+++ b/src/abtest_core/__init__.py
@@ -2,6 +2,7 @@
 
 from .types import MetricType, DataSchema, AnalysisConfig
 from .validation import validate_dataframe, infer_metric_type, ValidationError
+from .engine import AnalysisResult, analyze_groups
 
 __all__ = [
     "MetricType",
@@ -10,4 +11,6 @@ __all__ = [
     "validate_dataframe",
     "infer_metric_type",
     "ValidationError",
+    "AnalysisResult",
+    "analyze_groups",
 ]

--- a/src/abtest_core/engine.py
+++ b/src/abtest_core/engine.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+from .types import AnalysisConfig
+from .stats_binomial import prop_diff_test
+from .stats_continuous import welch_ttest, yuen_trimmed_mean_test, bootstrap_bca_ci
+from .stats_ratio import ratio_test
+
+
+@dataclass
+class AnalysisResult:
+    p_value: float
+    effect: float
+    ci: Tuple[float, float]
+    method_notes: str = ""
+
+
+def analyze_groups(df: pd.DataFrame, config: AnalysisConfig) -> AnalysisResult:
+    groups = df["group"].unique()
+    if len(groups) != 2:
+        raise ValueError("exactly two groups required")
+    g1 = df[df["group"] == groups[0]]["metric"]
+    g2 = df[df["group"] == groups[1]]["metric"]
+    notes = []
+    if config.metric_type == "binomial":
+        x1, n1 = g1.sum(), g1.count()
+        x2, n2 = g2.sum(), g2.count()
+        res = prop_diff_test(int(x1), int(n1), int(x2), int(n2), alpha=config.alpha, sided=config.sided)
+        p_value, effect, ci = res["p_value"], res["effect"], res["ci"]
+        notes.append(res["notes"])
+    elif config.metric_type == "continuous":
+        if config.robust:
+            res = yuen_trimmed_mean_test(g1.to_numpy(), g2.to_numpy(), alpha=config.alpha, sided=config.sided)
+        else:
+            mean1, var1, n1 = g1.mean(), g1.var(ddof=1), g1.count()
+            mean2, var2, n2 = g2.mean(), g2.var(ddof=1), g2.count()
+            res = welch_ttest(mean1, var1, n1, mean2, var2, n2, sided=config.sided, alpha=config.alpha)
+        p_value, effect, ci = res["p_value"], res["effect"], res["ci"]
+        notes.append(res["notes"])
+        if config.bootstrap:
+            ci = bootstrap_bca_ci(g1.to_numpy(), g2.to_numpy(), lambda a, b: np.mean(b) - np.mean(a), alpha=config.alpha)
+            notes.append("bootstrap_bca")
+    elif config.metric_type == "ratio":
+        mean1, var1, n1 = g1.mean(), g1.var(ddof=1), g1.count()
+        mean2, var2, n2 = g2.mean(), g2.var(ddof=1), g2.count()
+        res = ratio_test(mean1, var1, n1, mean2, var2, n2, alpha=config.alpha, sided=config.sided, fieller=config.use_fieller)
+        p_value, effect, ci = res["p_value"], res["effect"], res["ci"]
+        notes.append(res["notes"])
+    else:
+        raise ValueError("unknown metric type")
+    return AnalysisResult(p_value=p_value, effect=effect, ci=ci, method_notes=", ".join(notes))

--- a/src/abtest_core/stats_binomial.py
+++ b/src/abtest_core/stats_binomial.py
@@ -1,0 +1,52 @@
+import math
+from typing import Tuple, Dict
+
+from scipy.stats import norm
+
+
+def wilson_ci(x: int, n: int, alpha: float = 0.05) -> Tuple[float, float]:
+    if n <= 0:
+        return 0.0, 0.0
+    p = x / n
+    z = norm.ppf(1 - alpha / 2)
+    denom = 1 + z ** 2 / n
+    centre = (p + z ** 2 / (2 * n)) / denom
+    margin = z * math.sqrt(p * (1 - p) / n + z ** 2 / (4 * n ** 2)) / denom
+    return max(0.0, centre - margin), min(1.0, centre + margin)
+
+
+def newcombe_ci(x1: int, n1: int, x2: int, n2: int, alpha: float = 0.05) -> Tuple[float, float]:
+    p1_lo, p1_hi = wilson_ci(x1, n1, alpha)
+    p2_lo, p2_hi = wilson_ci(x2, n2, alpha)
+    return p1_lo - p2_hi, p1_hi - p2_lo
+
+
+def _p_value_from_z(z: float, sided: str = "two") -> float:
+    if sided == "two":
+        return 2 * (1 - norm.cdf(abs(z)))
+    if sided == "left":
+        return norm.cdf(z)
+    if sided == "right":
+        return 1 - norm.cdf(z)
+    raise ValueError("sided must be 'two', 'left', or 'right'")
+
+
+def prop_diff_test(
+    x1: int,
+    n1: int,
+    x2: int,
+    n2: int,
+    alpha: float = 0.05,
+    sided: str = "two",
+) -> Dict[str, object]:
+    if n1 <= 0 or n2 <= 0:
+        raise ValueError("sample sizes must be >0")
+    p1 = x1 / n1
+    p2 = x2 / n2
+    effect = p2 - p1
+    pooled = (x1 + x2) / (n1 + n2)
+    se = math.sqrt(pooled * (1 - pooled) * (1 / n1 + 1 / n2))
+    z = effect / se if se > 0 else 0.0
+    p_value = _p_value_from_z(z, sided)
+    ci = newcombe_ci(x1, n1, x2, n2, alpha)
+    return {"p_value": p_value, "effect": effect, "ci": ci, "notes": "newcombe"}

--- a/src/abtest_core/stats_continuous.py
+++ b/src/abtest_core/stats_continuous.py
@@ -1,0 +1,111 @@
+import math
+from typing import Tuple, Callable, Dict
+
+import numpy as np
+from scipy.stats import t, trim_mean, ttest_ind, norm
+
+
+def welch_ttest(
+    mean1: float,
+    var1: float,
+    n1: int,
+    mean2: float,
+    var2: float,
+    n2: int,
+    sided: str = "two",
+    alpha: float = 0.05,
+) -> Dict[str, object]:
+    effect = mean2 - mean1
+    se = math.sqrt(var1 / n1 + var2 / n2)
+    df_num = (var1 / n1 + var2 / n2) ** 2
+    df_den = (var1 ** 2) / (n1 ** 2 * (n1 - 1)) + (var2 ** 2) / (n2 ** 2 * (n2 - 1))
+    df = df_num / df_den if df_den > 0 else 1
+    t_stat = effect / se if se > 0 else 0.0
+    if sided == "two":
+        p_value = 2 * (1 - t.cdf(abs(t_stat), df))
+        t_crit = t.ppf(1 - alpha / 2, df)
+    elif sided == "left":
+        p_value = t.cdf(t_stat, df)
+        t_crit = t.ppf(1 - alpha, df)
+    elif sided == "right":
+        p_value = 1 - t.cdf(t_stat, df)
+        t_crit = t.ppf(1 - alpha, df)
+    else:
+        raise ValueError("sided must be 'two', 'left', or 'right'")
+    ci = (effect - t_crit * se, effect + t_crit * se)
+    return {"p_value": p_value, "effect": effect, "ci": ci, "notes": "welch"}
+
+
+def yuen_trimmed_mean_test(
+    a: np.ndarray,
+    b: np.ndarray,
+    trim: float = 0.2,
+    alpha: float = 0.05,
+    sided: str = "two",
+) -> Dict[str, object]:
+    a = np.asarray(a)
+    b = np.asarray(b)
+    stat, p_value = ttest_ind(a, b, equal_var=False, trim=trim)
+    m1 = trim_mean(a, proportiontocut=trim)
+    m2 = trim_mean(b, proportiontocut=trim)
+    effect = m2 - m1
+    g1 = int(trim * len(a))
+    g2 = int(trim * len(b))
+    a_win = np.sort(a)
+    b_win = np.sort(b)
+    if g1 > 0:
+        a_win[:g1] = a_win[g1]
+        a_win[-g1:] = a_win[-g1 - 1]
+    if g2 > 0:
+        b_win[:g2] = b_win[g2]
+        b_win[-g2:] = b_win[-g2 - 1]
+    wv1 = np.var(a_win, ddof=1)
+    wv2 = np.var(b_win, ddof=1)
+    n1 = len(a) - 2 * g1
+    n2 = len(b) - 2 * g2
+    se = math.sqrt(wv1 / (n1 * (n1 - 1)) + wv2 / (n2 * (n2 - 1)))
+    df_num = (wv1 / (n1 * (n1 - 1)) + wv2 / (n2 * (n2 - 1))) ** 2
+    df_den = (wv1 ** 2) / ((n1 ** 2) * (n1 - 1) ** 2 * (n1 - 1)) + (wv2 ** 2) / ((n2 ** 2) * (n2 - 1) ** 2 * (n2 - 1))
+    df = df_num / df_den if df_den > 0 else n1 + n2 - 2
+    if sided == "two":
+        t_crit = t.ppf(1 - alpha / 2, df)
+    else:
+        t_crit = t.ppf(1 - alpha, df)
+    ci = (effect - t_crit * se, effect + t_crit * se)
+    return {"p_value": p_value, "effect": effect, "ci": ci, "notes": "yuen"}
+
+
+def bootstrap_bca_ci(
+    a: np.ndarray,
+    b: np.ndarray,
+    fn_effect: Callable[[np.ndarray, np.ndarray], float],
+    alpha: float = 0.05,
+    iters: int = 5000,
+) -> Tuple[float, float]:
+    a = np.asarray(a)
+    b = np.asarray(b)
+    obs = fn_effect(a, b)
+    boot = []
+    n1, n2 = len(a), len(b)
+    for _ in range(iters):
+        sa = np.random.choice(a, n1, replace=True)
+        sb = np.random.choice(b, n2, replace=True)
+        boot.append(fn_effect(sa, sb))
+    boot = np.sort(boot)
+    z0 = norm.ppf((boot < obs).mean())
+    # jackknife
+    jacks = []
+    for i in range(n1):
+        jacks.append(fn_effect(np.delete(a, i), b))
+    for i in range(n2):
+        jacks.append(fn_effect(a, np.delete(b, i)))
+    jacks = np.array(jacks)
+    jack_mean = jacks.mean()
+    num = np.sum((jack_mean - jacks) ** 3)
+    den = 6 * (np.sum((jack_mean - jacks) ** 2) ** 1.5)
+    a_hat = num / den if den != 0 else 0.0
+    al = norm.cdf(z0 + (z0 + norm.ppf(alpha / 2)) / (1 - a_hat * (z0 + norm.ppf(alpha / 2))))
+    au = norm.cdf(z0 + (z0 + norm.ppf(1 - alpha / 2)) / (1 - a_hat * (z0 + norm.ppf(1 - alpha / 2))))
+    lo = np.percentile(boot, al * 100)
+    hi = np.percentile(boot, au * 100)
+    return lo, hi

--- a/src/abtest_core/stats_ratio.py
+++ b/src/abtest_core/stats_ratio.py
@@ -1,0 +1,69 @@
+import math
+from typing import Tuple, Dict
+
+from scipy.stats import norm
+
+
+def delta_mean_diff_ci(mean1: float, var1: float, n1: int, mean2: float, var2: float, n2: int, alpha: float = 0.05) -> Tuple[float, float]:
+    effect = mean2 - mean1
+    se = math.sqrt(var1 / n1 + var2 / n2)
+    z = norm.ppf(1 - alpha / 2)
+    return effect - z * se, effect + z * se
+
+
+def delta_ratio_ci(mean1: float, var1: float, n1: int, mean2: float, var2: float, n2: int, alpha: float = 0.05) -> Tuple[float, float]:
+    ratio = mean2 / mean1
+    se = ratio * math.sqrt(var1 / (n1 * mean1 ** 2) + var2 / (n2 * mean2 ** 2))
+    z = norm.ppf(1 - alpha / 2)
+    return ratio - z * se, ratio + z * se
+
+
+def fieller_ratio_ci(mean1: float, var1: float, n1: int, mean2: float, var2: float, n2: int, alpha: float = 0.05) -> Tuple[Tuple[float, float], str]:
+    a = mean1
+    b = mean2
+    va = var1 / n1
+    vb = var2 / n2
+    z = norm.ppf(1 - alpha / 2)
+    g = a * b
+    h = a ** 2 - z ** 2 * va
+    k = b ** 2 - z ** 2 * vb
+    if h <= 0:
+        return (-math.inf, math.inf), "fieller_unbounded"
+    discr = g ** 2 - h * k
+    if discr < 0:
+        discr = 0
+    root = math.sqrt(discr)
+    lo = (g - root) / h
+    hi = (g + root) / h
+    return (lo, hi), "fieller"
+
+
+def ratio_test(
+    mean1: float,
+    var1: float,
+    n1: int,
+    mean2: float,
+    var2: float,
+    n2: int,
+    alpha: float = 0.05,
+    sided: str = "two",
+    fieller: bool = False,
+) -> Dict[str, object]:
+    ratio = mean2 / mean1
+    log_ratio = math.log(ratio)
+    se_log = math.sqrt(var1 / (n1 * mean1 ** 2) + var2 / (n2 * mean2 ** 2))
+    z_stat = log_ratio / se_log if se_log > 0 else 0.0
+    if sided == "two":
+        p_value = 2 * (1 - norm.cdf(abs(z_stat)))
+    elif sided == "left":
+        p_value = norm.cdf(z_stat)
+    elif sided == "right":
+        p_value = 1 - norm.cdf(z_stat)
+    else:
+        raise ValueError("sided must be 'two', 'left', or 'right'")
+    if fieller:
+        ci, note = fieller_ratio_ci(mean1, var1, n1, mean2, var2, n2, alpha)
+    else:
+        ci = delta_ratio_ci(mean1, var1, n1, mean2, var2, n2, alpha)
+        note = "delta"
+    return {"p_value": p_value, "effect": ratio, "ci": ci, "notes": note}

--- a/src/abtest_core/types.py
+++ b/src/abtest_core/types.py
@@ -29,3 +29,6 @@ class AnalysisConfig(BaseModel):
     metric_type: MetricType
     segments: List[str] = []
     multiple_testing: Literal["none", "holm", "bonferroni", "by"] = "holm"
+    robust: bool = False
+    bootstrap: bool = False
+    use_fieller: bool = False

--- a/tests/test_stats_binomial.py
+++ b/tests/test_stats_binomial.py
@@ -1,0 +1,22 @@
+import pytest
+from abtest_core.stats_binomial import wilson_ci, newcombe_ci, prop_diff_test
+
+
+def test_binomial_ci_and_test():
+    x1, n1 = 40, 200
+    x2, n2 = 80, 200
+    p1 = x1 / n1
+    p2 = x2 / n2
+    diff = p2 - p1
+
+    lo, hi = wilson_ci(x1, n1)
+    assert lo < p1 < hi
+
+    dlo, dhi = newcombe_ci(x1, n1, x2, n2)
+    assert dlo < diff < dhi
+
+    res = prop_diff_test(x1, n1, x2, n2)
+    assert res["effect"] == pytest.approx(diff)
+    assert res["p_value"] < 0.05
+    lo, hi = res["ci"]
+    assert lo < diff < hi

--- a/tests/test_stats_continuous.py
+++ b/tests/test_stats_continuous.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+from abtest_core.stats_continuous import welch_ttest, yuen_trimmed_mean_test, bootstrap_bca_ci
+
+
+def test_welch_ttest():
+    np.random.seed(0)
+    a = np.random.normal(0, 1, 200)
+    b = np.random.normal(0.5, 1, 180)
+    mean1, var1, n1 = a.mean(), a.var(ddof=1), len(a)
+    mean2, var2, n2 = b.mean(), b.var(ddof=1), len(b)
+    res = welch_ttest(mean1, var1, n1, mean2, var2, n2)
+    diff = mean2 - mean1
+    assert diff > 0
+    lo, hi = res["ci"]
+    assert lo < diff < hi
+    assert res["p_value"] < 0.05
+
+
+def test_yuen_trimmed_mean():
+    np.random.seed(1)
+    a = np.concatenate([np.random.normal(0, 1, 200), np.array([20])])
+    b = np.random.normal(1, 1, 201)
+    res = yuen_trimmed_mean_test(a, b, trim=0.2)
+    eff = res["effect"]
+    assert eff > 0
+    lo, hi = res["ci"]
+    assert lo < eff < hi
+    assert res["p_value"] < 0.05
+
+
+def test_bootstrap_bca_ci():
+    np.random.seed(2)
+    a = np.random.normal(0, 1, 50)
+    b = np.random.normal(0.5, 1, 50)
+    fn = lambda x, y: np.mean(y) - np.mean(x)
+    lo, hi = bootstrap_bca_ci(a, b, fn, iters=2000)
+    diff = fn(a, b)
+    assert lo < diff < hi

--- a/tests/test_stats_ratio.py
+++ b/tests/test_stats_ratio.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from abtest_core.stats_ratio import ratio_test
+
+
+def test_ratio_delta_and_fieller():
+    np.random.seed(0)
+    a = np.random.normal(10, 2, 200)
+    b = np.random.normal(12, 2, 180)
+    mean1, var1, n1 = a.mean(), a.var(ddof=1), len(a)
+    mean2, var2, n2 = b.mean(), b.var(ddof=1), len(b)
+    effect = mean2 / mean1
+
+    res_delta = ratio_test(mean1, var1, n1, mean2, var2, n2)
+    assert res_delta["effect"] == pytest.approx(effect)
+    lo, hi = res_delta["ci"]
+    assert lo < effect < hi
+    assert res_delta["p_value"] < 0.05
+
+    res_fieller = ratio_test(mean1, var1, n1, mean2, var2, n2, fieller=True)
+    lo2, hi2 = res_fieller["ci"]
+    assert lo2 < effect < hi2
+    assert "fieller" in res_fieller["notes"]
+


### PR DESCRIPTION
## Summary
- add Wilson/Newcombe CIs and proportion test
- implement Welch t-test, Yuen trimmed mean, and BCa bootstrap CI
- support ratio metrics via delta and Fieller methods
- add unified analysis engine and expose through API with method notes
- add unit tests for new statistical engines

## Testing
- `pytest tests/test_stats_binomial.py tests/test_stats_continuous.py tests/test_stats_ratio.py tests/test_api_integration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6895be7f7638832ca73ec617520543ea