### PR TITLE
chore(log,config): redact PII, env secrets, unified error shape

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -3,12 +3,22 @@ disable_existing_loggers: False
 formatters:
   simple:
     format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+filters:
+  redact_pii:
+    (): utils.log_filters.RedactPIIFilter
 handlers:
   console:
     class: logging.StreamHandler
     level: INFO
     formatter: simple
+    filters: [redact_pii]
     stream: ext://sys.stdout
+  file:
+    class: logging.FileHandler
+    level: DEBUG
+    formatter: simple
+    filters: [redact_pii]
+    filename: debug.log
 root:
-  level: INFO
-  handlers: [console]
+  level: DEBUG
+  handlers: [console, file]

--- a/src/abtest_core/srm.py
+++ b/src/abtest_core/srm.py
@@ -22,9 +22,7 @@ class SrmCheckFailed(Exception):
                 "observed": self.result["observed"],
                 "p_value": self.result["p_value"],
             },
-            "actions": {
-                "force_run_when_srm_failed": True,
-            },
+            "fix_hint": "Проверьте распределение трафика или запустите с force_run_when_srm_failed",
         }
 
 

--- a/src/api/analysis.py
+++ b/src/api/analysis.py
@@ -27,7 +27,10 @@ from abtest_core import DataSchema, validate_dataframe, ValidationError
 
 def create_app() -> Flask:
     app = Flask(__name__)
-    app.config["JWT_SECRET_KEY"] = os.environ.get("JWT_SECRET_KEY", "secret")
+    jwt_secret = os.getenv("JWT_SECRET_KEY")
+    if not jwt_secret:
+        raise RuntimeError("JWT_SECRET_KEY environment variable is required")
+    app.config["JWT_SECRET_KEY"] = jwt_secret
     jwt = JWTManager(app)
 
     swaggerui_blueprint = get_swaggerui_blueprint(
@@ -78,7 +81,17 @@ def create_app() -> Flask:
             access = create_access_token(identity="admin")
             refresh = create_refresh_token(identity="admin")
             return jsonify(access_token=access, refresh_token=refresh)
-        return jsonify({"msg": "Bad credentials"}), 401
+        return (
+            jsonify(
+                {
+                    "code": "auth_failed",
+                    "title": "Bad credentials",
+                    "details": "Invalid username or password",
+                    "fix_hint": "Verify provided credentials",
+                }
+            ),
+            401,
+        )
 
     @app.post("/refresh")
     @jwt_required(refresh=True)

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -1,0 +1,6 @@
+{
+  "flags_db": "flags.db",
+  "history_db": "history.db",
+  "webhook_url": "https://example.com/webhook",
+  "theme": "dark"
+}

--- a/src/utils/log_filters.py
+++ b/src/utils/log_filters.py
@@ -1,0 +1,14 @@
+import logging
+import re
+
+class RedactPIIFilter(logging.Filter):
+    """Redact common PII fields from log messages."""
+
+    pattern = re.compile(r"(user_id|email)=([^\s,]+)")
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple regex
+        message = record.getMessage()
+        message = self.pattern.sub(lambda m: f"{m.group(1)}=***", message)
+        record.msg = message
+        record.args = ()
+        return True

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -11,6 +11,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 from api.flags import create_app as create_flags_app
 from api.analysis import create_app as create_analysis_app
 
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
 
 @pytest.fixture
 def flags_client(tmp_path):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -9,6 +9,8 @@ pytest.importorskip("flask_jwt_extended")
 
 from api.flags import create_app as create_flags_app
 
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
 
 def test_login_and_protected_endpoint():
     app = create_flags_app()

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -10,6 +10,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 from api.analysis import create_app as create_analysis_app
 from api.flags import create_app as create_flags_app
 
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
 
 def test_analysis_docs_available():
     app = create_analysis_app()


### PR DESCRIPTION
## Summary
- add PII redaction filter and debug file logging
- load JWT secrets from env and sample config without secrets
- standardize API error responses and SRM failure structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: No matching distribution found for pandas)*
- `pytest tests/test_jwt.py -q` *(skipped: flask)*

------
https://chatgpt.com/codex/tasks/task_e_6899c34f1b4c832cbfc755695cb44acd