### PR TITLE
ci: speed up with cache; pin py3.12; add ruff/mypy/bandit; remove lock step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,19 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
       - uses: snok/install-poetry@v1
       - name: Install deps
         run: poetry install --no-interaction --with dev --sync
+      - name: Lint
+        run: poetry run ruff check .
+      - name: Type check
+        run: poetry run mypy src
+      - name: Security check
+        run: poetry run bandit -q -r src
       - name: Run unit tests
         run: |
           poetry run coverage run -m pytest -q --ignore=tests/test_api_integration.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
       - uses: snok/install-poetry@v1
       - name: Install deps
         run: poetry install --no-interaction --with dev --sync

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
       - uses: snok/install-poetry@v1
       - name: Install deps
         run: poetry install --no-interaction --with dev --sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
-      - name: Install build tool
-        run: python -m pip install --upgrade build
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+      - uses: snok/install-poetry@v1
+      - name: Install deps
+        run: poetry install --no-interaction --with dev --sync
       - name: Check changelog updated
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -23,7 +28,7 @@ jobs:
             exit 1
           fi
       - name: Build package
-        run: python -m build
+        run: poetry build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1
         with:


### PR DESCRIPTION
## Summary
- cache pip and run lint, type, and security checks in CI
- cache pip for docs, publish, and release workflows
- build release with Poetry rather than raw build tool

## Testing
- `poetry run ruff check .` *(fails: Found 62 errors)*
- `poetry run mypy src` *(fails: Found 205 errors)*
- `poetry run bandit -q -r src`
- `poetry run coverage run -m pytest -q --ignore=tests/test_api_integration.py`
- `poetry run pytest -q tests/test_api_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6899c6228554832c883a45e927d8b24b